### PR TITLE
feat(docker): setup containerized Next.js and MariaDB dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Uses the official, lightweight Alpine Linux image with Node.js 22 LTS.
+FROM node:22-alpine
+
+# Sets the internal working directory.
+# All subsequent commands run inside this folder.
+WORKDIR /app
+
+# Copies ONLY the package files first.
+# This leverages Docker's layer caching so 'npm install' only re-runs if dependencies actually change.
+COPY package*.json ./
+
+# Installs all Node dependencies inside the isolated Linux container.
+RUN npm install
+
+# NOTE: We DO NOT copy the rest of the source code here (no 'COPY . .').
+# The docker-compose.yml handles that via a bind mount to enable instant hot-reloading.
+
+# Documents that the container will listen on port 3000 (Next.js default).
+EXPOSE 3000
+
+# Starts the Next.js development server when the container launches.
+CMD ["npm", "run", "dev"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+NAME := ft_transcendence
+
+DC := docker compose
+
+# Ensures 'make' runs 'all' by default
+.DEFAULT_GOAL := all
+
+all: $(NAME)
+
+$(NAME): up
+
+# Builds and starts the containers in the background
+# up --build : Forces fresh image compilation from Dockerfiles before starting.
+# -d         : Runs the stack in the background (detached mode).
+up:
+	@echo "Starting $(NAME) containers in the background..."
+	@$(DC) up --build -d
+
+# Starts the containers attached to the terminal (good for seeing live logs)
+dev:
+	@echo "Starting $(NAME) in development mode..."
+	@$(DC) up --build
+
+# Gracefully stops containers and the bridge network.
+# Leaves volumes intact.
+down:
+	@echo "Stopping $(NAME) containers..."
+	@$(DC) down
+
+# Shows the live logs of the containers
+# -f         : Follows the log output continuously.
+logs:
+	@$(DC) logs -f
+
+# Full Docker compose wipe.
+# down -v          : Deletes internal Docker named volumes (wipes the database).
+# --rmi all        : Deletes all custom built images for the services.
+# --remove-orphans : Cleans up ghost containers not currently in the compose file.
+# || true          : Prevents make from crashing if there is nothing to stop.
+clean:
+	@echo "Cleaning containers, volumes, and custom images..."
+	@$(DC) down -v --rmi all --remove-orphans || true
+
+# The Nuclear Option: Cleans the compose setup, then purges the entire Docker system.
+# system prune -a  : Removes all unused images, networks, and build cache.
+# --force          : Bypasses the terminal Y/N confirmation prompt.
+fclean: clean
+	@echo "Deep cleaning Docker environment..."
+	@docker system prune -a --force
+
+# Full factory reset: wipes everything and rebuilds from scratch.
+re: fclean all
+
+.PHONY: all up dev down logs clean fclean re

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+services:
+  nextjs:
+    # Builds the Next.js container using the Dockerfile inside our root folder
+    build:
+      context: .
+    container_name: transcendence_frontend
+    
+    # Maps <Host Port>:<Container Port>. Allows us to view the app at http://localhost:3000
+    ports:
+      - "3000:3000"
+      
+    volumes:
+      # 1. BIND MOUNT: Syncs our local source code into the container. 
+      # This enables hot-reloading so changes in VS Code show up instantly.
+      - .:/app
+      
+      # 2. ANONYMOUS VOLUME: Isolates the container's node_modules.
+      # Prevents our host OS dependencies from clashing with the container's internal dependencies.
+      - /app/node_modules
+      
+      # 3. ANONYMOUS VOLUME: Isolates the Next.js build cache.
+      # Prevents file permission conflicts between the host and the container.
+      - /app/.next
+      
+    environment:
+      # Ensures Docker reliably detects file saves for hot-reloading
+      - WATCHPACK_POLLING=true 
+      
+      # Pulls the constructed URL directly from the .env file automatically!
+      - DATABASE_URL
+      
+    # Ensures the database is up and running before Next.js tries to start
+    depends_on:
+      - mariadb
+
+  mariadb:
+    # Uses the official MariaDB image from Docker Hub
+    image: mariadb:latest
+    container_name: transcendence_db
+    
+    # Automatically restarts the database if it crashes
+    restart: always
+    
+    # Exposes the default DB port so we can connect external database viewers if needed
+    ports:
+      - "3306:3306"
+      
+    environment:
+      # Pulls our secure database credentials from the hidden .env file automatically!
+      - MARIADB_ROOT_PASSWORD
+      - MARIADB_DATABASE
+      - MARIADB_USER
+      - MARIADB_PASSWORD
+      
+    volumes:
+      # NAMED VOLUME: Saves database data permanently to the host machine.
+      # Without this, all users and stats would be wiped every time Docker shuts down.
+      - mariadb_data:/var/lib/mysql
+
+# Declares the named volume used by MariaDB
+volumes:
+  mariadb_data:

--- a/env.example
+++ b/env.example
@@ -1,0 +1,11 @@
+MARIADB_ROOT_PASSWORD=super_secret_root
+MARIADB_DATABASE=transcendence
+MARIADB_USER=pong_user
+MARIADB_PASSWORD=pong_password
+
+# Prisma Connection String (Used by Next.js to talk to the db container)
+# Format: mysql://USER:PASSWORD@HOST:PORT/DATABASE
+DATABASE_URL=mysql://${MARIADB_USER}:${MARIADB_PASSWORD}@mariadb:3306/${MARIADB_DATABASE}
+
+
+# RENAME THIS FILE TO .env TO MAKE IT WORK WITH THE CURRENT SETUP.


### PR DESCRIPTION
Implemented the day-one Docker architecture:
- Reorganized Next.js files into the `/frontend` directory for a cleaner root structure.
- Created `frontend/Dockerfile` to handle Node dependencies and the Next.js dev server.
- Set up `docker-compose.yml` to orchestrate Next.js (port 3000) and MariaDB (port 3306).
- Configured bind mounts for instant hot-reloading in VS Code.
- Isolated `node_modules` and `.next` build caches using anonymous volumes to prevent host/container OS conflicts.
- Created `mariadb_data` named volume for persistent database storage.
- Added a robust Makefile (up, dev, down, logs, clean, fclean).
- Fixed `.gitignore` to handle the new folder structure.

Anssi/Dimi -> ORM Next Steps:
The database infrastructure is live. The connection string is already being injected into the Next.js container as the `DATABASE_URL` environment variable. Your next step is to research, pick an ORM (Prisma or TypeORM recommended), install it in the frontend, and configure it to consume that URL so we can start building the user profile schemas.

Closes #5