### PR TITLE
Implement language switching function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,13 @@
         "@prisma/adapter-mariadb": "^7.5.0",
         "@prisma/client": "^7.5.0",
         "@react-three/fiber": "^9.5.0",
+        "i18next": "^25.10.9",
+        "i18next-browser-languagedetector": "^8.2.1",
         "next": "16.2.0",
         "next-auth": "^4.24.13",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-i18next": "^16.6.6",
         "three": "^0.183.2"
       },
       "devDependencies": {
@@ -4829,12 +4832,61 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-status-codes": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
       "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/i18next": {
+      "version": "25.10.9",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.9.tgz",
+      "integrity": "sha512-hQY9/bFoQKGlSKMlaCuLR8w1h5JjieqrsnZvEmj1Ja6Ec7fbyc4cTrCsY9mb9Sd8YQ/swsrKz1S9M8AcvVI70w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -6865,6 +6917,33 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.6.6",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+      "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.10.9",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8012,6 +8091,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -13,11 +13,14 @@
     "@prisma/adapter-mariadb": "^7.5.0",
     "@prisma/client": "^7.5.0",
     "@react-three/fiber": "^9.5.0",
+    "i18next": "^25.10.9",
+    "i18next-browser-languagedetector": "^8.2.1",
     "next": "16.2.0",
     "next-auth": "^4.24.13",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "three": "^0.183.2"
+    "three": "^0.183.2",
+    "react-i18next": "^16.6.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/i18n/i18n.ts
+++ b/src/app/i18n/i18n.ts
@@ -1,0 +1,26 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import en from "./locales/en.json";
+import fi from "./locales/fi.json";
+import zh from "./locales/zh.json";
+
+let isInitialized = false;
+
+export function initI18n() {
+  if (!isInitialized) {
+    i18n.use(initReactI18next).init({
+      resources: {
+        en: { translation: en },
+        fi: { translation: fi },
+        zh: { translation: zh },
+      },
+      fallbackLng: "en",
+      interpolation: { escapeValue: false },
+      react: { useSuspense: false },
+    });
+
+    isInitialized = true;
+  }
+}
+
+export default i18n;

--- a/src/app/i18n/locales/en.json
+++ b/src/app/i18n/locales/en.json
@@ -1,0 +1,26 @@
+{
+  "footer": {
+    "language": "Language",
+    "dark": "Dark",
+    "light": "Light",
+    "languageLabel": {
+      "en": "English",
+      "fi": "Suomi",
+      "zh": "中文"
+    }
+  },
+  "header": {
+    "websitename": "Website Name",
+    "home": "Home",
+    "game": "Game",
+    "friends": "Friends",
+    "profile": "Profile",
+    "login": "Login",
+    "registration": "Registration",
+    "default": "Default Page Title",
+    "play": "Play"
+  },
+  "home": {
+    "title": "Home Page"
+  }
+}

--- a/src/app/i18n/locales/fi.json
+++ b/src/app/i18n/locales/fi.json
@@ -1,0 +1,21 @@
+{
+  "footer": {
+    "language": "Kieli",
+    "dark": "Tumma",
+    "light": "Vaalea"
+  },
+  "header": {
+    "websitename": "Verkkosivuston Nimi",
+    "home": "Etusivu",
+    "game": "Peli",
+    "friends": "Ystävät",
+    "profile": "Profiili",
+    "login": "Kirjaudu",
+    "registration": "Rekisteröidy",
+    "default": "Oletussivu",
+    "play": "Pelaa"
+  },
+  "home": {
+    "title": "Etusivu"
+  }
+}

--- a/src/app/i18n/locales/zh.json
+++ b/src/app/i18n/locales/zh.json
@@ -1,0 +1,21 @@
+{
+  "footer": {
+    "language": "语言",
+    "dark": "暗色",
+    "light": "亮色"
+  },
+  "header": {
+    "websitename": "网站名称",
+    "home": "主页",
+    "game": "游戏",
+    "friends": "好友",
+    "profile": "个人资料",
+    "login": "登录",
+    "registration": "注册",
+    "default": "默认页面",
+    "play": "开始"
+  },
+  "home": {
+    "title": "首页"
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,14 @@
 // Home page
+"use client";
+
+import { useTranslation } from "react-i18next";
 
 export default function Home() {
+  const { t } = useTranslation();
+
   return (
     <div>
-      <h1>Home Page</h1>
+      <h1>{t("home.title")}</h1>
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,17 +2,21 @@
 
 /**
  * TODO
- * 1-Language change button will changed later, so didn't make a component now
- * 2-light mode control need to be changed to a toggle button or more clear display
+ * 1-light mode control need to be changed to a toggle button or more clear display
  */
 
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Bar from "@/components/Bar";
+import { useTranslation } from "react-i18next";
+import Button from "@/components/Button";
 
 export default function Footer() {
   const [dark, setDark] = useState(false);
+  const { t, i18n } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (dark) {
@@ -22,17 +26,60 @@ export default function Footer() {
     }
   }, [dark]);
 
+  // get language list from i18n files
+  const languages = Object.keys(i18n.options.resources || {}).map((code) => ({
+    code,
+    label: t(`footer.languageLabel.${code}`, code),
+  }));
+  const currentLang =
+    languages.find((l) => l.code === i18n.language) || languages[0];
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
   return (
     <Bar className="justify-end gap-2.5">
-      <button className="px-4 py-2 rounded-xl bg-button text-text hover:bg-button-hover transition-colors">
-        EN
-      </button>
+      <div className="relative w-26" ref={ref}>
+        {/* button shows current languge */}
+        <Button className="w-26" onClick={() => setOpen(!open)}>
+          {currentLang.label}
+        </Button>
+
+        {/* Drop-down menu for choosing language */}
+        {open && (
+          <ul className="absolute z-10 w-full mb-1 bottom-full bg-button rounded-xl shadow-lg overflow-hidden">
+            {languages.map((lang) => (
+              <li
+                key={lang.code}
+                onClick={() => {
+                  i18n.changeLanguage(lang.code);
+                  setOpen(false);
+                }}
+                className={`
+                  px-4 py-2 cursor-pointer
+                  hover:bg-button-hover
+                  ${i18n.language === lang.code ? "bg-button-active text-white" : "text-text"}
+                `}
+              >
+                {lang.label}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
 
       <button
         onClick={() => setDark(!dark)}
-        className="px-4 py-2 rounded-xl bg-button text-text hover:bg-button-hover transition-colors"
+        className="w-26 px-4 py-2 rounded-xl bg-button text-text hover:bg-button-hover transition-colors"
       >
-        {dark ? "Light" : "Dark"}
+        {dark ? t("footer.light") : t("footer.dark")}
       </button>
     </Bar>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,27 +16,29 @@ import Bar from "@/components/Bar";
 import NavButton from "@/components/NavButton";
 import { GitSignInButton } from "@/components/buttons/github-signin";
 import { SignOutButton } from "@/components/buttons/sign-out-button";
+import { useTranslation } from "react-i18next";
 
 export default function Header() {
   const pathname = usePathname();
   const { data: session } = useSession();
+  const { t } = useTranslation();
 
   const getTitle = () => {
     switch (pathname) {
       case "/":
-        return "Home";
+        return t("header.home");
       case "/game":
-        return "Game";
+        return t("header.game");
       case "/friends":
-        return "Friends";
+        return t("header.friends");
       case "/profile":
-        return "Profile";
+        return t("header.profile");
       case "/login":
-        return "Login";
+        return t("header.login");
       case "/registration":
-        return "Registration";
+        return t("header.registration");
       default:
-        return "Default Page Title";
+        return t("header.default");
     }
   };
 
@@ -55,7 +57,7 @@ export default function Header() {
           height={32}
         />
         <span className="text-2xl text-text font-extrabold leading-none">
-          Website Name
+          {t("header.websitename")}
         </span>
       </Link>
 
@@ -65,15 +67,15 @@ export default function Header() {
       {/* buttons */}
       <div className="flex items-center gap-2.5">
         <NavButton href="/game" active={pathname === "/game"}>
-          Play
+          {t("header.play")}
         </NavButton>
 
         <NavButton href="/friends" active={pathname === "/friends"}>
-          Friends
+          {t("header.friends")}
         </NavButton>
 
         <NavButton href="/profile" active={pathname === "/profile"}>
-          Profile
+          {t("header.profile")}
         </NavButton>
 
         {session?.user?.image && (

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { SessionProvider } from "next-auth/react";
+import { I18nextProvider } from "react-i18next";
+import i18n, { initI18n } from "@/app/i18n/i18n";
+
+initI18n();
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+    </SessionProvider>
+  );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
-export default {
+const config = {
   content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
   darkMode: "class",
 };
+
+export default config;


### PR DESCRIPTION
Implemented a basic internationalization (i18n) system using `react-i18next` to support multiple languages and dynamic switching via UI.

* Added translation support (en, fi, zh)
* Created JSON translation files
* Implemented language switcher (Footer dropdown)
* All Header, Footer, and Home page texts are now translatable

### Future Work

* Login, Registration, Game, and other pages will be localized later after UI is finalized

### Notes
For features that don't have specific requirements for the subject, we can consider adding them in the future(if we have time).
* Add locale-based routing (/en, /zh, etc.)
* Persist selected language (URL or cookie)