### PR TITLE
Fix devcontainer workspace folder name

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "name": "Transcendence Devcontainer",
   "dockerComposeFile": ["./docker-compose.yml"],
   "service": "devcontainer",
-  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "workspaceFolder": "/workspaces/transcendence",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
We hardcode the mount name in .devcontainer/docker-compose.yml to mount only the project folder and not anything outside it. We must specify the matching workspaceFolder in devcontainer.json because the parent directory name might be something else on each developer's computer.