### PR TITLE
Adjust Makefile for the containerization changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,27 +7,27 @@ DC := docker compose
 
 all: $(NAME)
 
-$(NAME): up
+$(NAME): dev
 
-# Builds and starts the containers in the background
+# Starts the database container and then runs Next.js dev server
+dev: up
+	@echo "Starting $(NAME) Next.js dev server"
+	@npm run dev
+
+# Builds and starts the database container in the background.
 # up --build : Forces fresh image compilation from Dockerfiles before starting.
 # -d         : Runs the stack in the background (detached mode).
 up:
-	@echo "Starting $(NAME) containers in the background..."
+	@echo "Starting $(NAME) database container in the background..."
 	@$(DC) up --build -d
 
-# Starts the containers attached to the terminal (good for seeing live logs)
-dev:
-	@echo "Starting $(NAME) in development mode..."
-	@$(DC) up --build
-
-# Gracefully stops containers and the bridge network.
+# Stop the database container.
 # Leaves volumes intact.
 down:
 	@echo "Stopping $(NAME) containers..."
 	@$(DC) down
 
-# Shows the live logs of the containers
+# Shows the live logs of the database container
 # -f         : Follows the log output continuously.
 logs:
 	@$(DC) logs -f


### PR DESCRIPTION
* In devcontainer, database runs automatically in another container. Start Next.js dev server directly with `npm run dev`. Do not use `make`, it will fail because docker is not installed inside the container.
* Outside of devcontainer:
  * `make up` to start the database
  * `make stop` to stop the database
  * `make dev` or `make` ensures that the database is started and then runs Next.js dev server with `npm run dev`.
  * Stop the dev server with ctrl-C. Database remains running until `make stop`.