### PR TITLE
Remove automatic restart of the database Docker container

### DIFF
--- a/docker/mariadb.yml
+++ b/docker/mariadb.yml
@@ -2,7 +2,6 @@
 services:
   mariadb:
     image: mariadb:latest
-    restart: on-failure
 
     environment:
       - MARIADB_ROOT_PASSWORD


### PR DESCRIPTION
On-failure restart condition does not trigger only with container crashes, but also on host computer crash and seemingly even controlled restart. This is unexpected to project developers, and contrary to Docker documentation.

Leave the restart condition as unset (default: no) instead. The MariaDB container is unlikely to crash unexpectedly, and developer can always restart it manually.

---

You probably need to rebuild containers for this to take effect.