### PR TITLE
Fix GitHub authentication

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,6 +12,7 @@ export const authOptions: NextAuthOptions = {
       clientId: process.env.GITHUB_ID!,
       clientSecret: process.env.GITHUB_SECRET!,
       allowDangerousEmailAccountLinking: true,
+      issuer: "https://github.com/login/oauth",
     }),
     CredentialsProvider({
       name: "Credentials",


### PR DESCRIPTION
It appears GitHub has recently implemented RFC 9207[1] for their OAuth implementation, and now includes an Issuer Identifier (`iss` parameter) in their OAuth response redirect URLs:
`/api/auth/callback/github?code=[...]&iss=https%3A%2F%2Fgithub.com%2Flogin%2Foauth&state=[...]`

Our authentication libraries want to validate this identifier if it's present, and reject the response in case of mismatch or if there is no expected identifier configured[2].

Make GitHub authentication work again by configuring the expected issuer identifier.

[1] https://datatracker.ietf.org/doc/html/rfc9207
[2] https://github.com/panva/openid-client/blob/v5.7.1/lib/client.js#L450-L452