### PR TITLE
[feat:] Unique Username implementation

### DIFF
--- a/prisma/migrations/20260420135300_add_displayname_unique/migration.sql
+++ b/prisma/migrations/20260420135300_add_displayname_unique/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[displayName]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX `User_displayName_key` ON `User`(`displayName`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,7 +21,7 @@ model User {
   password      String?
   image         String?
 
-  displayName  String?
+  displayName  String?   @unique
   bio          String?   @db.Text
   avatarUrl    String?   @db.Text
   avatarData   Bytes?

--- a/src/actions/account.ts
+++ b/src/actions/account.ts
@@ -73,7 +73,10 @@ export async function updateProfileAction(formData: FormData) {
     revalidatePath("/profile");
 
     return { ok: true };
-  } catch {
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message.includes("Unique constraint")) {
+      return { ok: false, error: apiErrors.displayNameTaken };
+    }
     return { ok: false, error: apiErrors.missingFields };
   }
 }

--- a/src/actions/registration.ts
+++ b/src/actions/registration.ts
@@ -168,3 +168,12 @@ export async function completeRegistrationProfileAction(formData: FormData) {
     return { ok: false, error: apiErrors.errorUnexpected };
   }
 }
+
+export async function checkUsernameAvailableAction(
+  username: string,
+): Promise<{ available: boolean }> {
+  const existing = await prisma.user.findUnique({
+    where: { displayName: username },
+  });
+  return { available: !existing };
+}

--- a/src/app/registration/profile/page.tsx
+++ b/src/app/registration/profile/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import Button from "@/components/Button";
 import { useTranslation } from "react-i18next";
-import { completeRegistrationProfileAction } from "@/actions/registration";
+import {
+  completeRegistrationProfileAction,
+  checkUsernameAvailableAction,
+} from "@/actions/registration";
 
 type AvatarChoice = "default" | "github" | "upload";
 
@@ -14,6 +17,10 @@ export default function ProfileSetupPage() {
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [usernameAvailable, setUsernameAvailable] = useState<boolean | null>(
+    null,
+  );
+  const [checkingUsername, setCheckingUsername] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const { t } = useTranslation();
@@ -31,8 +38,25 @@ export default function ProfileSetupPage() {
     }
   };
 
+  useEffect(() => {
+    if (!displayName.trim()) {
+      setUsernameAvailable(null);
+      return;
+    }
+    setCheckingUsername(true);
+    const timeout = setTimeout(async () => {
+      const { available } = await checkUsernameAvailableAction(
+        displayName.trim(),
+      );
+      setUsernameAvailable(available);
+      setCheckingUsername(false);
+    }, 500);
+    return () => clearTimeout(timeout);
+  }, [displayName]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!usernameAvailable) return;
     setError("");
     setLoading(true);
 
@@ -70,9 +94,13 @@ export default function ProfileSetupPage() {
       window.dispatchEvent(new Event("avatar-updated"));
       window.location.href = "/";
     } catch (err: unknown) {
-      setError(
-        err instanceof Error ? err.message : t("profile.errorUnexpected"),
-      );
+      if (err instanceof Error && err.message.includes("Unique constraint")) {
+        setError(t("profile.usernameTaken"));
+      } else {
+        setError(
+          err instanceof Error ? err.message : t("profile.errorUnexpected"),
+        );
+      }
       setLoading(false);
     }
   };
@@ -96,16 +124,33 @@ export default function ProfileSetupPage() {
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col gap-1">
             <label className="text-sm font-medium text-text/70">
-              {t("profile.displayNameLabel")}
+              {t("profile.userNameLabel")}
             </label>
             <input
               type="text"
-              placeholder={t("profile.displayNamePlaceholder")}
+              placeholder={t("profile.userNamePlaceholder")}
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
               className="w-full px-4 py-2.5 rounded-lg text-sm text-text bg-button border border-purple-light placeholder:text-text/40 focus:outline-none focus:ring-2 focus:ring-purple-light transition-all"
               required
             />
+            {displayName.trim() && (
+              <p
+                className={`text-xs mt-0.5 ${
+                  checkingUsername
+                    ? "text-text/40"
+                    : usernameAvailable
+                      ? "text-green-500"
+                      : "text-red-500"
+                }`}
+              >
+                {checkingUsername
+                  ? t("profile.usernameChecking")
+                  : usernameAvailable
+                    ? t("profile.usernameAvailable")
+                    : t("profile.usernameTaken")}
+              </p>
+            )}
           </div>
 
           <div className="flex flex-col gap-2">
@@ -191,7 +236,7 @@ export default function ProfileSetupPage() {
 
           <Button
             type="submit"
-            disabled={loading}
+            disabled={loading || !usernameAvailable || checkingUsername}
             className="bg-gradient-to-r from-blue-dark to-purple-dark mt-1 text-white text-xl"
           >
             {loading ? t("profile.loading") : t("profile.submit")}

--- a/src/components/EditProfileForm.tsx
+++ b/src/components/EditProfileForm.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import Button from "./Button";
 import { updateProfileAction } from "@/actions/account";
+import { checkUsernameAvailableAction } from "@/actions/registration";
 
 interface EditProfileFormProps {
   displayName: string | null;
@@ -28,11 +29,31 @@ export function EditProfileForm({
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [usernameAvailable, setUsernameAvailable] = useState<boolean | null>(
+    null,
+  );
+  const [checkingUsername, setCheckingUsername] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const router = useRouter();
   const { t } = useTranslation();
 
   const bioTooLong = bioValue.length > BIO_MAX;
+
+  useEffect(() => {
+    if (!nameValue.trim() || nameValue.trim() === (displayName ?? "").trim()) {
+      setUsernameAvailable(null);
+      return;
+    }
+    setCheckingUsername(true);
+    const timeout = setTimeout(async () => {
+      const { available } = await checkUsernameAvailableAction(
+        nameValue.trim(),
+      );
+      setUsernameAvailable(available);
+      setCheckingUsername(false);
+    }, 500);
+    return () => clearTimeout(timeout);
+  }, [nameValue, displayName]);
 
   const clearSelectedFile = () => {
     setFileValue(null);
@@ -48,6 +69,8 @@ export function EditProfileForm({
       setError(t("settings.account.bioTooLong", { max: BIO_MAX }));
       return;
     }
+
+    if (checkingUsername || usernameAvailable === false) return;
 
     setLoading(true);
     setError("");
@@ -66,7 +89,11 @@ export function EditProfileForm({
 
     if (!result.ok) {
       const key = result.error;
-      setError(t(`apiErrors.${key}`, t("profile.errorFallback")));
+      if (key === "DISPLAY_NAME_TAKEN") {
+        setError(t("profile.usernameTaken"));
+      } else {
+        setError(t(`apiErrors.${key}`, t("profile.errorFallback")));
+      }
     } else {
       setSuccess(true);
       clearSelectedFile();
@@ -77,11 +104,13 @@ export function EditProfileForm({
     setLoading(false);
   };
 
+  const nameChanged = nameValue.trim() !== (displayName ?? "").trim();
+
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       <div className="flex flex-col gap-1">
         <label className="text-sm font-medium text-text/70">
-          {t("settings.account.displayName")}
+          {t("settings.account.userName")}
         </label>
         <input
           type="text"
@@ -89,6 +118,23 @@ export function EditProfileForm({
           onChange={(e) => setNameValue(e.target.value)}
           className="w-full px-4 py-2.5 rounded-lg text-sm text-text bg-button border border-purple-light placeholder:text-text/40 focus:outline-none focus:ring-2 focus:ring-purple-light transition-all"
         />
+        {nameChanged && nameValue.trim() && (
+          <p
+            className={`text-xs mt-0.5 ${
+              checkingUsername
+                ? "text-text/40"
+                : usernameAvailable
+                  ? "text-green-500"
+                  : "text-red-500"
+            }`}
+          >
+            {checkingUsername
+              ? t("profile.usernameChecking")
+              : usernameAvailable
+                ? t("profile.usernameAvailable")
+                : t("profile.usernameTaken")}
+          </p>
+        )}
       </div>
 
       <div className="flex flex-col gap-1">
@@ -184,7 +230,12 @@ export function EditProfileForm({
 
       <Button
         type="submit"
-        disabled={loading || bioTooLong}
+        disabled={
+          loading ||
+          bioTooLong ||
+          checkingUsername ||
+          usernameAvailable === false
+        }
         className="mt-1 bg-gradient-to-r from-blue-dark to-purple-dark text-white text-base"
       >
         {loading

--- a/src/components/EditProfileForm.tsx
+++ b/src/components/EditProfileForm.tsx
@@ -15,6 +15,38 @@ interface EditProfileFormProps {
 
 const BIO_MAX = 150;
 
+function useUsernameCheck(nameValue: string, originalName: string | null) {
+  const [usernameAvailable, setUsernameAvailable] = useState<boolean>(true);
+  const [checkingUsername, setCheckingUsername] = useState(false);
+
+  useEffect(() => {
+    const trimmed = nameValue.trim();
+    const isUnchanged = trimmed === (originalName ?? "").trim();
+
+    if (!trimmed || isUnchanged) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const timeout = setTimeout(async () => {
+      setCheckingUsername(true);
+      const { available } = await checkUsernameAvailableAction(trimmed);
+      if (!cancelled) {
+        setUsernameAvailable(available);
+        setCheckingUsername(false);
+      }
+    }, 500);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeout);
+    };
+  }, [nameValue, originalName]);
+
+  return { usernameAvailable, checkingUsername };
+}
+
 export function EditProfileForm({
   displayName,
   bio,
@@ -29,31 +61,17 @@ export function EditProfileForm({
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [usernameAvailable, setUsernameAvailable] = useState<boolean | null>(
-    null,
-  );
-  const [checkingUsername, setCheckingUsername] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const router = useRouter();
   const { t } = useTranslation();
 
-  const bioTooLong = bioValue.length > BIO_MAX;
+  const { usernameAvailable, checkingUsername } = useUsernameCheck(
+    nameValue,
+    displayName,
+  );
 
-  useEffect(() => {
-    if (!nameValue.trim() || nameValue.trim() === (displayName ?? "").trim()) {
-      setUsernameAvailable(null);
-      return;
-    }
-    setCheckingUsername(true);
-    const timeout = setTimeout(async () => {
-      const { available } = await checkUsernameAvailableAction(
-        nameValue.trim(),
-      );
-      setUsernameAvailable(available);
-      setCheckingUsername(false);
-    }, 500);
-    return () => clearTimeout(timeout);
-  }, [nameValue, displayName]);
+  const bioTooLong = bioValue.length > BIO_MAX;
+  const nameChanged = nameValue.trim() !== (displayName ?? "").trim();
 
   const clearSelectedFile = () => {
     setFileValue(null);
@@ -70,7 +88,7 @@ export function EditProfileForm({
       return;
     }
 
-    if (checkingUsername || usernameAvailable === false) return;
+    if (checkingUsername || (nameChanged && !usernameAvailable)) return;
 
     setLoading(true);
     setError("");
@@ -89,7 +107,7 @@ export function EditProfileForm({
 
     if (!result.ok) {
       const key = result.error;
-      if (key === "DISPLAY_NAME_TAKEN") {
+      if (key === "displayNameTaken") {
         setError(t("profile.usernameTaken"));
       } else {
         setError(t(`apiErrors.${key}`, t("profile.errorFallback")));
@@ -98,13 +116,10 @@ export function EditProfileForm({
       setSuccess(true);
       clearSelectedFile();
       router.refresh();
-      window.dispatchEvent(new Event("avatar-updated"));
     }
 
     setLoading(false);
   };
-
-  const nameChanged = nameValue.trim() !== (displayName ?? "").trim();
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
@@ -234,7 +249,7 @@ export function EditProfileForm({
           loading ||
           bioTooLong ||
           checkingUsername ||
-          usernameAvailable === false
+          (nameChanged && !usernameAvailable)
         }
         className="mt-1 bg-gradient-to-r from-blue-dark to-purple-dark text-white text-base"
       >

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -157,8 +157,11 @@
   "profile": {
     "title": "Set up your Profile",
     "subtitle": "Choose how you'll appear to others",
-    "displayNameLabel": "Display name",
-    "displayNamePlaceholder": "Type your display name",
+    "userNameLabel": "Username",
+    "userNamePlaceholder": "Type your Username",
+    "usernameChecking": "Checking...",
+    "usernameAvailable": "✓ Username is available",
+    "usernameTaken": "✗ Username is already taken",
     "submit": "CONTINUE",
     "loading": "Saving...",
     "errorFallback": "Profile setup failed",
@@ -180,7 +183,7 @@
     },
     "account": {
       "title": "Account",
-      "displayName": "Display name",
+      "userName": "Username",
       "email": "Email",
       "bio": "Bio",
       "bioTooLong": "Bio must be {{max}} characters or fewer",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -151,8 +151,11 @@
   "profile": {
     "title": "Luo profiilisi",
     "subtitle": "Valitse, miten sinut näytetään muille",
-    "displayNameLabel": "Näyttönimi",
-    "displayNamePlaceholder": "Kirjoita näyttönimesi",
+    "userNameLabel": "Käyttäjänimi",
+    "userNamePlaceholder": "Kirjoita käyttäjänimesi",
+    "usernameChecking": "Tarkistetaan...",
+    "usernameAvailable": "✓ Käyttäjänimi on saatavilla",
+    "usernameTaken": "✗ Käyttäjänimi on jo käytössä",
     "submit": "JATKA",
     "loading": "Tallennetaan...",
     "errorFallback": "Profiilin luonti epäonnistui",
@@ -174,7 +177,7 @@
     },
     "account": {
       "title": "Tili",
-      "displayName": "Näyttönimi",
+      "userName": "Käyttäjänimi",
       "email": "Sähköposti",
       "bio": "Bio",
       "bioTooLong": "Bion on oltava enintään {{max}} merkkiä",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -151,8 +151,11 @@
   "profile": {
     "title": "设置您的资料",
     "subtitle": "选择您希望展示给他人的名称",
-    "displayNameLabel": "显示名称",
-    "displayNamePlaceholder": "请输入您的显示名称",
+    "userNameLabel": "用户名",
+    "userNamePlaceholder": "请输入您的用户名",
+    "usernameChecking": "检查中...",
+    "usernameAvailable": "✓ 用户名可用",
+    "usernameTaken": "✗ 用户名已被占用",
     "submit": "继续",
     "loading": "保存中...",
     "errorFallback": "资料设置失败",
@@ -174,7 +177,7 @@
     },
     "account": {
       "title": "账户",
-      "displayName": "显示名称",
+      "userName": "用户名",
       "email": "电子邮件",
       "bio": "简介",
       "bioTooLong": "简介不能超过 {{max}} 个字符",


### PR DESCRIPTION
To prevent the issue where there is duplicate name entries when searching for friends, we decided during the meeting to make it so that the Username will be unique and thus there will be no possibility to have double entries in the friends search bar results. 

As discussed, the code for the db/backend is kept as before, i.e. the entries are represented by 'display name' to make it easier and not have excessive changes to the code. The placeholder/interface that the user will be seeing holds the 'Username' value. 

While we had said that the validation would be easier to conduct once the submit button is clicked, I actually implemented a check while typing/after typing so this will not allow the user to click the button if the username is not available. 

Checks had to be included in two different instances: 
1) During first registration where user is prompted to set their unique username::
<img width="721" height="358" alt="image" src="https://github.com/user-attachments/assets/830887db-5fe9-46c6-bb05-91f84a6add2e" />

<img width="732" height="340" alt="image" src="https://github.com/user-attachments/assets/47f23766-7f6e-4cf2-aed0-0f91e5280aa1" />

2) In the settings page / edit profile form where the user can change their username: 
<img width="1046" height="238" alt="image" src="https://github.com/user-attachments/assets/9cf0deb2-62b9-4cc1-ae12-de0e62cbf904" />

<img width="1094" height="609" alt="image" src="https://github.com/user-attachments/assets/4665b82a-d516-4dbf-9226-be4b3d0302f3" />



**NOTES:** 
- The 'username is taken' is not triggered if the user types their own username, it will not show anything, they will be able to click save changes and it will say 'Profile updated successfully' as per usual 
<img width="1086" height="459" alt="image" src="https://github.com/user-attachments/assets/08a266c2-0dbe-4ba7-a99f-38d2ed59eccc" />
 
- In the case two users happen to try to change to the same exact username at the same time, and they both pass the 'Username is available' validation, the user that is faster will be able to change it, while the slower user will still be able to click the submit button (because validation passed) but then once they try to save it will be caught as an error: 
<img width="1074" height="819" alt="image" src="https://github.com/user-attachments/assets/b65bce1a-6929-44bb-9fb4-a4c3e5e7ae20" />


**Additional files changed:** 

- Translation files where the username entries were changed from display name to username and also adding the validation/error messages needed. The Chinese translation have already been validated by Ying, so only Finnish translation has to be double checked 

-  Prisma specific file changes (schema + migration) for display name -> '@unique' value has been added to display name entry and then migration was conducted to include this 