### PR TITLE
Pass avatarVersion through session

### DIFF
--- a/src/app/registration/profile/page.tsx
+++ b/src/app/registration/profile/page.tsx
@@ -17,7 +17,7 @@ export default function ProfileSetupPage() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const { t } = useTranslation();
-  const { data: session } = useSession();
+  const { data: session, update: updateSession } = useSession();
 
   const showGithubOption = !!session?.user?.image;
 
@@ -67,7 +67,7 @@ export default function ProfileSetupPage() {
         );
       }
 
-      window.dispatchEvent(new Event("avatar-updated"));
+      updateSession();
       window.location.href = "/";
     } catch (err: unknown) {
       setError(

--- a/src/components/EditProfileForm.tsx
+++ b/src/components/EditProfileForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import Button from "./Button";
 import { updateProfileAction } from "@/actions/account";
+import { useSession } from "next-auth/react";
 
 interface EditProfileFormProps {
   displayName: string | null;
@@ -31,6 +32,7 @@ export function EditProfileForm({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const router = useRouter();
   const { t } = useTranslation();
+  const { update: updateSession } = useSession();
 
   const bioTooLong = bioValue.length > BIO_MAX;
 
@@ -71,7 +73,7 @@ export function EditProfileForm({
       setSuccess(true);
       clearSelectedFile();
       router.refresh();
-      window.dispatchEvent(new Event("avatar-updated"));
+      updateSession();
     }
 
     setLoading(false);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
@@ -16,34 +15,9 @@ export default function Header() {
   const { data: session, status } = useSession();
   const { t } = useTranslation();
 
-  const [avatarVersion, setAvatarVersion] = useState(() => {
-    if (typeof window === "undefined") {
-      return 0;
-    }
-
-    const stored = sessionStorage.getItem("avatarVersion");
-    return stored ? Number(stored) : 0;
-  });
-
-  useEffect(() => {
-    // Header stays mounted while the current user updates their avatar in
-    // settings or during profile setup. We persist the version so avatar
-    // refreshes also survive full page navigations.
-    const handleAvatarUpdated = () => {
-      const nextVersion = Date.now();
-      sessionStorage.setItem("avatarVersion", String(nextVersion));
-      setAvatarVersion(nextVersion);
-    };
-
-    window.addEventListener("avatar-updated", handleAvatarUpdated);
-    return () => {
-      window.removeEventListener("avatar-updated", handleAvatarUpdated);
-    };
-  }, []);
-
   const avatarSrc =
     status === "authenticated" && session.user?.id
-      ? `/api/avatar/${session.user.id}?v=${avatarVersion}`
+      ? `/api/avatar/${session.user.id}?v=${session.user.avatarVersion}`
       : "/images/user_icon.png";
 
   return (

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -52,7 +52,15 @@ export const authOptions: NextAuthOptions = {
       return token;
     },
     session: async ({ session, token }) => {
+      const user = await prisma.user.findUnique({
+        where: { id: token.userId },
+        select: {
+          updatedAt: true,
+        },
+      });
+
       session.user.id = token.userId;
+      session.user.avatarVersion = user?.updatedAt.getTime();
       return session;
     },
   },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -4,6 +4,7 @@ declare module "next-auth" {
   interface Session {
     user: {
       id: string;
+      avatarVersion?: number;
     } & DefaultSession["user"];
   }
 }


### PR DESCRIPTION
The purpose of `avatarVersion` is to ensure we use the latest avatar image whenever user changes their avatar. The avatar endpoint only provides the latest image, but we want the images to be cacheable, so the URL needs to change to prevent using a previously cached image.

We're currently pushing `avatarVersion` updates from avatar-changing code to the `Header` component using a custom DOM event, and caching the value in `sessionStorage`. This works while the stored value remains available, but breaks if the user closes the browser tab or uses a different browser. `avatarVersion` defaults to zero, and if the user registered recently, the image optimizer cache likely still has the default image for the `?v=0` URL, shown briefly in the post-registration page even if the user immediately selects their own avatar.

To work reliably, `avatarVersion` must come from the server. The session object is a natural place for the current user's `avatarVersion`. We can also remove the custom event and simply re-fetch the session object from the server. The session object is shared with the entire React tree under `SessionProvider`, so calling the update function returned by `useSession()` also re-renders other users like `Header`.