### PR TITLE
[feat:] adding Avatar on User Profile Page

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -40,12 +40,14 @@ async function getProfileData(email: string) {
 
   return {
     user: {
+      id: user.id,
       displayName: user.displayName,
       username: user.username,
       name: user.name,
       email: user.email,
       bio: user.bio,
       avatarUrl: user.avatarUrl,
+      avatarVersion: user.updatedAt.getTime(),
       joinedAt: fmt(user.createdAt, {
         day: "2-digit",
         month: "2-digit",

--- a/src/components/profile/Profileclient.tsx
+++ b/src/components/profile/Profileclient.tsx
@@ -12,6 +12,7 @@ export function ProfileClient({ data }: { data: NonNullable<ProfileData> }) {
     user.displayName || user.username || user.name || t("profilePage.title");
 
   const recentMatches = user.matches.slice(0, 20);
+  const avatarSrc = `/api/avatar/${user.id}?v=${user.avatarVersion}`;
 
   return (
     <div className="flex-1 overflow-y-auto p-4 sm:p-6" suppressHydrationWarning>
@@ -21,19 +22,14 @@ export function ProfileClient({ data }: { data: NonNullable<ProfileData> }) {
           {/* Title card with avatar */}
           <div className="bg-card rounded-2xl border border-purple-light p-6 shadow-xl flex flex-col items-center gap-3 sm:flex-row sm:gap-4">
             <div className="w-20 h-20 rounded-xl border-2 border-purple-light bg-purple-light/20 flex items-center justify-center shrink-0 overflow-hidden">
-              {user.avatarUrl ? (
-                <Image
-                  src={user.avatarUrl}
-                  alt={displayName}
-                  width={80}
-                  height={80}
-                  className="w-full h-full object-cover"
-                />
-              ) : (
-                <span className="text-2xl font-bold text-text/50">
-                  {displayName.charAt(0).toUpperCase()}
-                </span>
-              )}
+              <Image
+                unoptimized
+                src={avatarSrc}
+                alt={displayName}
+                width={80}
+                height={80}
+                className="w-full h-full object-cover"
+              />
             </div>
             <div className="text-center sm:text-left">
               <h1 className="text-3xl font-bold text-text">


### PR DESCRIPTION
The Avatar was missing from the User Profile Page, it is now implemented and has been added to fill up the square next to the Page Title. 

The changes were implemented in the same as the settings page, so using the api/avatar, passing the user id and the avatarVersion to it, and  then using the result with 'Image'. The avatars are matching in the Header, User Profile Page and Settings Page: 
<img width="960" height="381" alt="image" src="https://github.com/user-attachments/assets/04aa0006-0e26-4711-8651-74d368f6577f" />

<img width="960" height="381" alt="image" src="https://github.com/user-attachments/assets/b7f0fbc2-f990-475e-a33f-9a0713c14b54" />

The changes also apply for when you use the Github Signin and the default avatar (the default avatar is being changed by Ying and thus will look different soon), respectively as follows: 
<img width="1243" height="356" alt="image" src="https://github.com/user-attachments/assets/9f51514c-1e07-4b98-b47d-9e22eed358c9" />

<img width="1243" height="356" alt="image" src="https://github.com/user-attachments/assets/e5b9f2d8-7f90-4c8f-af63-cb90b7080cb6" />