### PR TITLE
fixed fontWarning

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,10 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "@/app/globals.css";
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { Providers } from "@/components/Providers";
 import { cookies } from "next/headers";
-
-const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -27,9 +20,7 @@ export default async function RootLayout({
 
   return (
     <html className={dark ? "dark" : ""}>
-      <body
-        className={`bg-gradient-to-br from-purple-light to-blue-light ${geistSans.variable} ${geistMono.variable}`}
-      >
+      <body className={`bg-gradient-to-br from-purple-light to-blue-light`}>
         <Providers initialLang={lang}>
           <div className="h-screen flex flex-col">
             <div className="pt-5 px-5">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -71,8 +71,6 @@ export default function Header() {
           <span className="block w-8 h-8 shrink-0 rounded-full overflow-hidden">
             <Image
               unoptimized
-              loading="eager"
-              priority
               src={avatarSrc}
               alt="user"
               width={32}


### PR DESCRIPTION
Seems like we declared these fonts and were loading them and never actually using them, so on Firefox it was giving a Warning: 

The resource at “[http://localhost:3000/_next/static/media/caa3a2e1cccd8315-s.p.16t1db8_9y2o~.woff2”](http://localhost:3000/_next/static/media/caa3a2e1cccd8315-s.p.16t1db8_9y2o~.woff2%E2%80%9D) preloaded with link preload was not used within a few seconds. Make sure all attributes of the preload tag are set correctly.

Since we are actually not using the Fonts anywhere, I deleted these fonts from layout.tsx and it seems that the warnings disappear. 

I was also getting this warning on firefox: 
The resource at “[http://localhost:3000/images/user_icon.png”](http://localhost:3000/images/user_icon.png%E2%80%9D) preloaded with link preload was not used within a few seconds. Make sure all attributes of the preload tag are set correctly.

To fix that warning regarding the Image, I removed these lines: 
loading="eager"
priority

These two warning are not present anymore.              