### PR TITLE
[fix:] user Session check after db clearing

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -81,11 +81,7 @@ export default function Header() {
         </NavButton>
 
         {/* Sign in/out button depending on session */}
-        {status === "authenticated" && session?.user ? (
-          <SignOutButton />
-        ) : (
-          <SignInButton />
-        )}
+        {session?.user ? <SignOutButton /> : <SignInButton />}
       </div>
     </Bar>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -81,7 +81,11 @@ export default function Header() {
         </NavButton>
 
         {/* Sign in/out button depending on session */}
-        {session ? <SignOutButton /> : <SignInButton />}
+        {status === "authenticated" && session?.user ? (
+          <SignOutButton />
+        ) : (
+          <SignInButton />
+        )}
       </div>
     </Bar>
   );

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -4,19 +4,18 @@ import { SessionProvider, useSession, signOut } from "next-auth/react";
 import { I18nextProvider } from "react-i18next";
 import { createI18n } from "@/i18n/i18n";
 
-function SessionGuard({ children }: { children: React.ReactNode }) {
-  const { data: session, status } = useSession();
+function SessionGuard() {
+  const { data: session } = useSession();
 
   useEffect(() => {
-    if (
-      status === "unauthenticated" ||
-      (status === "authenticated" && !session?.user)
-    ) {
+    // The session is invalid if server doesn't recognize the user.
+    // Clear out the useless session cookie to avoid confusion.
+    if (session && !session.user) {
       signOut({ redirect: false });
     }
-  }, [status, session]);
+  }, [session]);
 
-  return <>{children}</>;
+  return null;
 }
 
 export function Providers({
@@ -30,9 +29,8 @@ export function Providers({
 
   return (
     <SessionProvider>
-      <SessionGuard>
-        <I18nextProvider i18n={i18nInstance}>{children}</I18nextProvider>
-      </SessionGuard>
+      <SessionGuard />
+      <I18nextProvider i18n={i18nInstance}>{children}</I18nextProvider>
     </SessionProvider>
   );
 }

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,8 +1,23 @@
 "use client";
-import { useState } from "react";
-import { SessionProvider } from "next-auth/react";
+import { useState, useEffect } from "react";
+import { SessionProvider, useSession, signOut } from "next-auth/react";
 import { I18nextProvider } from "react-i18next";
 import { createI18n } from "@/i18n/i18n";
+
+function SessionGuard({ children }: { children: React.ReactNode }) {
+  const { data: session, status } = useSession();
+
+  useEffect(() => {
+    if (
+      status === "unauthenticated" ||
+      (status === "authenticated" && !session?.user)
+    ) {
+      signOut({ redirect: false });
+    }
+  }, [status, session]);
+
+  return <>{children}</>;
+}
 
 export function Providers({
   children,
@@ -15,7 +30,9 @@ export function Providers({
 
   return (
     <SessionProvider>
-      <I18nextProvider i18n={i18nInstance}>{children}</I18nextProvider>
+      <SessionGuard>
+        <I18nextProvider i18n={i18nInstance}>{children}</I18nextProvider>
+      </SessionGuard>
     </SessionProvider>
   );
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import { NextAuthOptions, Session } from "next-auth";
+import { NextAuthOptions } from "next-auth";
 import GitHubProvider from "next-auth/providers/github";
 import CredentialsProvider from "next-auth/providers/credentials";
 import bcrypt from "bcrypt";
@@ -60,11 +60,13 @@ export const authOptions: NextAuthOptions = {
       });
 
       if (!user) {
-        return { ...session, user: undefined } as unknown as Session;
+        return { ...session, user: undefined };
       }
 
-      session.user.id = token.userId;
-      session.user.avatarVersion = user?.updatedAt.getTime();
+      if (session.user) {
+        session.user.id = token.userId;
+        session.user.avatarVersion = user?.updatedAt.getTime();
+      }
       return session;
     },
   },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import { NextAuthOptions } from "next-auth";
+import { NextAuthOptions, Session } from "next-auth";
 import GitHubProvider from "next-auth/providers/github";
 import CredentialsProvider from "next-auth/providers/credentials";
 import bcrypt from "bcrypt";
@@ -58,6 +58,10 @@ export const authOptions: NextAuthOptions = {
           updatedAt: true,
         },
       });
+
+      if (!user) {
+        return { ...session, user: undefined } as unknown as Session;
+      }
 
       session.user.id = token.userId;
       session.user.avatarVersion = user?.updatedAt.getTime();

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -2,7 +2,7 @@ import { DefaultSession } from "next-auth";
 
 declare module "next-auth" {
   interface Session {
-    user: {
+    user?: {
       id: string;
       avatarVersion?: number;
     } & DefaultSession["user"];


### PR DESCRIPTION
There was some issue with the session token still having the user set as authenticated, which caused the signout button to be shown instead of the singin. And also the avatar was showing as '?' because the session was authenticated but there was no user  to be found. 
This was happening in the cases where you would login then rebuild the project and reload the page, then showing as follows: 
<img width="1217" height="149" alt="Screenshot from 2026-04-23 16-40-51" src="https://github.com/user-attachments/assets/30b5bbcd-e5de-4be6-b783-64b3154fd55d" />

To fix this I went with a 'Session Guard' function that will be ran on each page through the RootLayout, this makes sure that there is a valid session running at all times. 

NOTE: 
This line: 
if (!user) {
        return { ...session, user: undefined } as unknown as Session;
      }

Might not be the cleanest way, however it was giving me some errors with returning null and such, so this was the solution I found which returns a session with no user data, which SessionGuard will detect as unauthenticated and clear the cookie

I tested this and it seems to not cause any warnings or errors and the header is refreshed correctly, with no more question mark / old avatar being present. 
We discussed with Anssi about some edge cases regarding deleting a user in another window and then refreshing, and this causes the old avatar to still be there, but this is okay to keep and is something that is likely not to happen. When the page is refreshed , everything clears correctly, it will only be the header that kept the avatar, so data was not showing or something like that. 