### PR TITLE
[fix:] the bug when reading last opponent cookie in setup

### DIFF
--- a/src/game/ui/GameSetup.tsx
+++ b/src/game/ui/GameSetup.tsx
@@ -29,9 +29,8 @@ export default function GameSetup({
     initialPrefs?.gameType ?? "classic",
   );
   const [selectedOpponent, setSelectedOpponent] = useState<GameOpponent>(
-    initialPrefs?.opponent !== "human"
-      ? (initialPrefs?.opponent ?? "medium")
-      : "medium",
+    initialPrefs?.opponent === "human"
+      ? "human" : (initialPrefs?.opponent ?? "medium"),
   );
   const [guestName, setGuestName] = useState("");
   const [aiDifficulty, setAiDifficulty] = useState<"easy" | "medium" | "hard">(


### PR DESCRIPTION
The original problem was: 
When a user logged in, and selected a guest opponent in the game setup menu. After the game ended, returning to setup page, it always resulted in the default opponent being AI, not the guest opponent selected in the previous match.

After fixing: 
When a user logs in, if there was a previous match history in cookie, the opponent will be the one selected in last match (the guest's name will not be stored and displayed, but the selected opponent will still be the guest).