### PR TITLE
fix(game-engine): Finalize physics sub-stepping, AI multi-bounce trac…

### DIFF
--- a/src/game/3d/Arena.tsx
+++ b/src/game/3d/Arena.tsx
@@ -14,7 +14,6 @@ const TEXT_PROPS = {
 
 // SideWall abstracts the complex bounding box and top/side framing geometry to keep the parent clean
 const SideWall = memo(function SideWall({ z }: { z: number }) {
-  // Kept inside the component to satisfy the architectural request regarding static vs dynamic memory
   const HALF_WIDTH = GameConfig.court.width / 2;
 
   const glassMatRef = useRef<THREE.MeshStandardMaterial>(null!);

--- a/src/game/3d/GameRender.tsx
+++ b/src/game/3d/GameRender.tsx
@@ -201,7 +201,7 @@ const GameUpdate = memo(function GameUpdate({
       ...keys.current,
       ...aiKeys,
     });
-  }, -1);
+  }, -1); // Priority -1 ensures this physics update runs before 3D meshes read the state
 
   return null;
 });

--- a/src/game/AIOpponent.ts
+++ b/src/game/AIOpponent.ts
@@ -63,7 +63,36 @@ export class AIOpponent {
         this.targetZ = 0;
         this.targetX = GameConfig.player2.xPos;
       } else {
-        this.targetZ = ball.z + this.currentMistakeZ;
+        const zLimit = GameConfig.paddle.zLimit;
+
+        // Multi-bounce trajectory prediction
+        if (ball.vy < -0.01 && ball.y > GameConfig.ball.radius) {
+          // Ball falling: Predict floor intercept
+          const timeToFloor =
+            (ball.y - GameConfig.ball.radius) / Math.abs(ball.vy);
+          const predictedZ = ball.z + ball.vz * timeToFloor;
+          this.targetZ =
+            Math.max(Math.min(predictedZ, zLimit), -zLimit) +
+            this.currentMistakeZ;
+        } else if (ball.vy > 0.01) {
+          // Ball rising: Predict ceiling ricochet -> then floor intercept
+          const CEILING =
+            GameConfig.court.wallHeight * 3 - GameConfig.ball.radius;
+          const timeToCeiling = (CEILING - ball.y) / ball.vy;
+          const zAtCeiling = ball.z + ball.vz * timeToCeiling;
+
+          const vyAfterCeiling = -ball.vy * GameConfig.ball.bounceFriction;
+          const timeFromCeilingToFloor =
+            (CEILING - GameConfig.ball.radius) / Math.abs(vyAfterCeiling);
+          const predictedZ = zAtCeiling + ball.vz * timeFromCeilingToFloor;
+
+          this.targetZ =
+            Math.max(Math.min(predictedZ, zLimit), -zLimit) +
+            this.currentMistakeZ;
+        } else {
+          this.targetZ = ball.z + this.currentMistakeZ;
+        }
+
         const isBallTooHigh = ball.y > GameConfig.paddle.height;
 
         if (ball.vx > 0 && ball.x > GameConfig.court.centerX) {

--- a/src/game/GamePrefs.ts
+++ b/src/game/GamePrefs.ts
@@ -126,6 +126,7 @@ export function applySettingsToConfig(p: SettingsPrefs) {
   GameConfig.ball.startVelocityX = Math.round(12 * bsf);
   GameConfig.ball.startVelocityZ = Math.round(10 * bsf);
   GameConfig.ball.maxXVelocity = Math.round(28 * bsf);
+  GameConfig.ball.maxZVelocity = Math.round(14 * bsf);
 
   GameConfig.ball.gravity = Math.round(5 + ((p.gravity - 1) / 9) * 35);
   GameConfig.ball.bounceFriction = parseFloat(

--- a/src/game/PongEngine.ts
+++ b/src/game/PongEngine.ts
@@ -1,59 +1,89 @@
 import { GameConfig } from "@/game/GameConfig";
 import { GameType } from "@/game/GameState";
 
-// Helper constant to establish the vertical center of the paddle based on configured height.
-const PADDLE_Y = GameConfig.paddle.height / 2;
-// Pre-calculated effective Z limit to keep the ball's outer radius strictly within the court bounds.
-const EFFECTIVE_Z_LIMIT = GameConfig.court.zLimit - GameConfig.ball.radius;
-
 export class PongEngine {
   public ball = { x: 0, y: 0, z: 0, vx: 0, vy: 0, vz: 0, spin: 0 };
 
-  public p1 = { x: GameConfig.player1.xPos, y: PADDLE_Y, z: 0, vx: 0, vz: 0 };
-  public p2 = { x: GameConfig.player2.xPos, y: PADDLE_Y, z: 0, vx: 0, vz: 0 };
+  public p1: PaddleData;
+  public p2: PaddleData;
 
   public serveTimer = 0;
   private nextServeDirection: 1 | 2 = 1;
   private onScore: (player: 1 | 2) => void;
   public mode: GameType;
 
+  // Dynamic constants evaluated at match start to respect any GameConfig mutations
+  private PADDLE_Y: number;
+  private EFFECTIVE_Z_LIMIT: number;
+  private CEILING: number;
+
   constructor(onScore: (player: 1 | 2) => void, mode: GameType) {
     this.onScore = onScore;
     this.mode = mode;
+
+    // Evaluate physics limits dynamically based on current settings
+    this.PADDLE_Y = GameConfig.paddle.height / 2;
+    this.EFFECTIVE_Z_LIMIT = GameConfig.court.zLimit - GameConfig.ball.radius;
+    // Invisible stratosphere ceiling to allow high lobs without camera overshoot
+    this.CEILING = GameConfig.court.wallHeight * 3;
+
+    this.p1 = {
+      x: GameConfig.player1.xPos,
+      y: this.PADDLE_Y,
+      z: 0,
+      vx: 0,
+      vz: 0,
+    };
+    this.p2 = {
+      x: GameConfig.player2.xPos,
+      y: this.PADDLE_Y,
+      z: 0,
+      vx: 0,
+      vz: 0,
+    };
+
     this.initializeBall(1, false);
   }
 
+  // The main update loop acting as the Sub-stepping Manager
   public update(delta: number, keys: Record<string, boolean>) {
-    // Clamping protects against Division-by-Zero and physics tunneling during extreme frame drops.
-    const safeDelta = Math.max(
-      0.0001,
-      Math.min(delta, GameConfig.physics.maxDelta),
-    );
+    const safeDelta = Math.max(0.0001, Math.min(delta, 0.1));
+    const TIME_STEP = 1 / 120;
+    let timeAccumulator = safeDelta;
 
+    while (timeAccumulator > 0) {
+      const stepDelta = Math.min(timeAccumulator, TIME_STEP);
+      this.stepPhysics(stepDelta, keys);
+      timeAccumulator -= stepDelta;
+    }
+  }
+
+  private stepPhysics(delta: number, keys: Record<string, boolean>) {
     if (this.mode === "classic") {
-      this.updateClassicPaddles(safeDelta, keys);
+      this.updateClassicPaddles(delta, keys);
     } else {
-      this.updateAdvancedPaddles(safeDelta, keys);
+      this.updateAdvancedPaddles(delta, keys);
     }
 
     if (this.serveTimer > 0) {
-      this.serveTimer -= safeDelta * 1000;
+      this.serveTimer -= delta * 1000;
 
-      // The velocity guard IS necessary! It differentiates between a ball flying into the abyss
-      // after a point is scored, and a stationary ball waiting to be served (preventing premature gravity drops).
+      // Maintain ball motion and boundary checks during the serve delay point-scoring sequence
       if (this.ball.vx !== 0 || this.ball.vz !== 0) {
-        this.ball.x += this.ball.vx * safeDelta;
-        this.ball.z += this.ball.vz * safeDelta;
+        this.ball.x += this.ball.vx * delta;
+        this.ball.z += this.ball.vz * delta;
 
         if (this.mode === "advanced") {
-          this.ball.vy -= GameConfig.ball.gravity * safeDelta;
-          this.ball.y += this.ball.vy * safeDelta;
-          this.ball.vz += this.ball.spin * safeDelta;
+          this.ball.vy -= GameConfig.ball.gravity * delta;
+          this.ball.y += this.ball.vy * delta;
+          this.ball.vz += this.ball.spin * delta;
           this.ball.vz = Math.max(
             Math.min(this.ball.vz, GameConfig.ball.maxZVelocity),
             -GameConfig.ball.maxZVelocity,
           );
         }
+
+        this.resolveStaticBoundaries();
       }
 
       if (this.serveTimer <= 0) {
@@ -64,17 +94,17 @@ export class PongEngine {
     }
 
     if (this.mode === "classic") {
-      this.updateClassicBall(safeDelta);
+      this.updateClassicBall(delta);
     } else {
-      this.updateAdvancedBall(safeDelta);
+      this.updateAdvancedBall(delta);
     }
 
-    this.checkPaddle(this.p1, 1, safeDelta);
-    this.checkPaddle(this.p2, 2, safeDelta);
+    this.checkPaddle(this.p1, 1, delta);
+    this.checkPaddle(this.p2, 2, delta);
 
     this.resolveStaticBoundaries();
 
-    // Goal line detection. Physics are suspended via the serveTimer once a boundary is crossed.
+    // Goal line detection
     if (this.ball.x > GameConfig.court.xLimit) {
       this.onScore(1);
       this.nextServeDirection = 2;
@@ -92,14 +122,41 @@ export class PongEngine {
     const p1Keys = GameConfig.player1.controls;
     const p2Keys = GameConfig.player2.controls;
 
-    if (keys[p1Keys.up]) this.p1.z -= speed * delta;
-    else if (keys[p1Keys.down]) this.p1.z += speed * delta;
+    // Explicitly set velocities so Classic Mode hooks into Relative CCD correctly
+    this.p1.vz = 0;
+    if (keys[p1Keys.up]) this.p1.vz = -speed;
+    else if (keys[p1Keys.down]) this.p1.vz = speed;
 
-    if (keys[p2Keys.up]) this.p2.z -= speed * delta;
-    else if (keys[p2Keys.down]) this.p2.z += speed * delta;
+    this.p2.vz = 0;
+    if (keys[p2Keys.up]) this.p2.vz = -speed;
+    else if (keys[p2Keys.down]) this.p2.vz = speed;
 
-    this.p1.z = Math.max(Math.min(this.p1.z, zLimit), -zLimit);
-    this.p2.z = Math.max(Math.min(this.p2.z, zLimit), -zLimit);
+    this.p1.vx = 0;
+    this.p2.vx = 0;
+
+    // Player 1 Z limits and Phantom Momentum prevention
+    const nextP1Z = this.p1.z + this.p1.vz * delta;
+    if (nextP1Z >= zLimit) {
+      this.p1.z = zLimit;
+      this.p1.vz = 0;
+    } else if (nextP1Z <= -zLimit) {
+      this.p1.z = -zLimit;
+      this.p1.vz = 0;
+    } else {
+      this.p1.z = nextP1Z;
+    }
+
+    // Player 2 Z limits and Phantom Momentum prevention
+    const nextP2Z = this.p2.z + this.p2.vz * delta;
+    if (nextP2Z >= zLimit) {
+      this.p2.z = zLimit;
+      this.p2.vz = 0;
+    } else if (nextP2Z <= -zLimit) {
+      this.p2.z = -zLimit;
+      this.p2.vz = 0;
+    } else {
+      this.p2.z = nextP2Z;
+    }
   }
 
   private updateAdvancedPaddles(delta: number, keys: Record<string, boolean>) {
@@ -112,43 +169,73 @@ export class PongEngine {
     const p1Keys = GameConfig.player1.controls;
     const p2Keys = GameConfig.player2.controls;
 
+    // Apply exponential decay friction to handle variable frame rates gracefully
     if (keys[p1Keys.up]) this.p1.vz -= accel * delta;
     else if (keys[p1Keys.down]) this.p1.vz += accel * delta;
-    else this.p1.vz *= 1 - fric * delta;
+    else this.p1.vz *= Math.exp(-fric * delta);
 
     if (keys[p1Keys.left]) this.p1.vx -= accel * delta;
     else if (keys[p1Keys.right]) this.p1.vx += accel * delta;
-    else this.p1.vx *= 1 - fric * delta;
+    else this.p1.vx *= Math.exp(-fric * delta);
 
     if (keys[p2Keys.up]) this.p2.vz -= accel * delta;
     else if (keys[p2Keys.down]) this.p2.vz += accel * delta;
-    else this.p2.vz *= 1 - fric * delta;
+    else this.p2.vz *= Math.exp(-fric * delta);
 
     if (keys[p2Keys.left]) this.p2.vx -= accel * delta;
     else if (keys[p2Keys.right]) this.p2.vx += accel * delta;
-    else this.p2.vx *= 1 - fric * delta;
+    else this.p2.vx *= Math.exp(-fric * delta);
 
+    // Clamp absolute velocities
     this.p1.vz = Math.max(Math.min(this.p1.vz, maxVel), -maxVel);
     this.p1.vx = Math.max(Math.min(this.p1.vx, maxVel), -maxVel);
     this.p2.vz = Math.max(Math.min(this.p2.vz, maxVel), -maxVel);
     this.p2.vx = Math.max(Math.min(this.p2.vx, maxVel), -maxVel);
 
-    this.p1.z = Math.max(
-      Math.min(this.p1.z + this.p1.vz * delta, zLimit),
-      -zLimit,
-    );
-    this.p1.x = Math.max(
-      -GameConfig.paddle.xMax,
-      Math.min(-GameConfig.paddle.xMin, this.p1.x + this.p1.vx * delta),
-    );
-    this.p2.z = Math.max(
-      Math.min(this.p2.z + this.p2.vz * delta, zLimit),
-      -zLimit,
-    );
-    this.p2.x = Math.max(
-      GameConfig.paddle.xMin,
-      Math.min(GameConfig.paddle.xMax, this.p2.x + this.p2.vx * delta),
-    );
+    // Calculate next positions and zero out velocity if hitting a wall bounds
+    const nextP1Z = this.p1.z + this.p1.vz * delta;
+    if (nextP1Z >= zLimit) {
+      this.p1.z = zLimit;
+      this.p1.vz = 0;
+    } else if (nextP1Z <= -zLimit) {
+      this.p1.z = -zLimit;
+      this.p1.vz = 0;
+    } else {
+      this.p1.z = nextP1Z;
+    }
+
+    const nextP1X = this.p1.x + this.p1.vx * delta;
+    if (nextP1X >= -GameConfig.paddle.xMin) {
+      this.p1.x = -GameConfig.paddle.xMin;
+      this.p1.vx = 0;
+    } else if (nextP1X <= -GameConfig.paddle.xMax) {
+      this.p1.x = -GameConfig.paddle.xMax;
+      this.p1.vx = 0;
+    } else {
+      this.p1.x = nextP1X;
+    }
+
+    const nextP2Z = this.p2.z + this.p2.vz * delta;
+    if (nextP2Z >= zLimit) {
+      this.p2.z = zLimit;
+      this.p2.vz = 0;
+    } else if (nextP2Z <= -zLimit) {
+      this.p2.z = -zLimit;
+      this.p2.vz = 0;
+    } else {
+      this.p2.z = nextP2Z;
+    }
+
+    const nextP2X = this.p2.x + this.p2.vx * delta;
+    if (nextP2X >= GameConfig.paddle.xMax) {
+      this.p2.x = GameConfig.paddle.xMax;
+      this.p2.vx = 0;
+    } else if (nextP2X <= GameConfig.paddle.xMin) {
+      this.p2.x = GameConfig.paddle.xMin;
+      this.p2.vx = 0;
+    } else {
+      this.p2.x = nextP2X;
+    }
   }
 
   private updateClassicBall(delta: number) {
@@ -169,71 +256,92 @@ export class PongEngine {
       -GameConfig.ball.maxZVelocity,
     );
 
-    this.ball.spin *= 1 - GameConfig.ball.spinFriction * delta;
+    this.ball.spin *= Math.exp(-GameConfig.ball.spinFriction * delta);
   }
 
   private resolveStaticBoundaries() {
-    // Floor collision dampening for advanced mode gravity.
-    if (this.mode === "advanced" && this.ball.y <= GameConfig.ball.radius) {
-      this.ball.y = GameConfig.ball.radius;
-      if (this.ball.vy < 0)
-        this.ball.vy = -this.ball.vy * GameConfig.ball.bounceFriction;
+    if (this.mode === "advanced") {
+      if (this.ball.y <= GameConfig.ball.radius) {
+        this.ball.y = GameConfig.ball.radius;
+        if (this.ball.vy < 0)
+          this.ball.vy = -this.ball.vy * GameConfig.ball.bounceFriction;
+      }
+      // Ceiling bounds check to prevent camera overshoot
+      else if (this.ball.y >= this.CEILING - GameConfig.ball.radius) {
+        this.ball.y = this.CEILING - GameConfig.ball.radius;
+        if (this.ball.vy > 0)
+          this.ball.vy = -this.ball.vy * GameConfig.ball.bounceFriction;
+      }
     }
 
-    // Side wall inversions.
-    if (this.ball.z >= EFFECTIVE_Z_LIMIT) {
-      this.ball.z = EFFECTIVE_Z_LIMIT;
+    if (this.ball.z >= this.EFFECTIVE_Z_LIMIT) {
+      this.ball.z = this.EFFECTIVE_Z_LIMIT;
       if (this.ball.vz > 0) this.ball.vz *= -1;
-    } else if (this.ball.z <= -EFFECTIVE_Z_LIMIT) {
-      this.ball.z = -EFFECTIVE_Z_LIMIT;
+    } else if (this.ball.z <= -this.EFFECTIVE_Z_LIMIT) {
+      this.ball.z = -this.EFFECTIVE_Z_LIMIT;
       if (this.ball.vz < 0) this.ball.vz *= -1;
     }
   }
 
-  private checkPaddle(paddle: typeof this.p1, player: 1 | 2, delta: number) {
+  private checkPaddle(paddle: PaddleData, player: 1 | 2, delta: number) {
     const r = GameConfig.ball.radius;
     const hitW = GameConfig.paddle.width / 2 + r;
     const hitD = GameConfig.paddle.depth / 2 + r;
     const hitH = GameConfig.paddle.height / 2 + r;
 
     const dx = this.ball.x - paddle.x;
-    const dy = this.ball.y - PADDLE_Y;
+    const dy = this.ball.y - this.PADDLE_Y;
     const dz = this.ball.z - paddle.z;
 
     const prevX = this.ball.x - this.ball.vx * delta;
-    const planeX =
-      player === 1
-        ? paddle.x + GameConfig.paddle.width / 2 + r
-        : paddle.x - GameConfig.paddle.width / 2 - r;
+    const prevY = this.ball.y - this.ball.vy * delta;
+    const prevZ = this.ball.z - this.ball.vz * delta;
+
+    // Evaluate positions relative to the moving paddle frame of reference
+    const prevPaddleX = paddle.x - paddle.vx * delta;
+    const prevPaddleZ = paddle.z - paddle.vz * delta;
+
+    const relPlaneX = player === 1 ? hitW : -hitW;
+    const prevRelX = prevX - prevPaddleX;
+    const currentRelX = this.ball.x - paddle.x;
+    const relVX = this.ball.vx - paddle.vx;
 
     let hitFrontFace = false;
+    let crossBallZ = this.ball.z;
+    let crossPaddleZ_saved = paddle.z;
 
-    // Continuous Collision Detection (CCD) prevents high-velocity tunneling by
-    // mathematically checking if the ball's trajectory crossed the paddle's X-plane
-    // within the current frame, gated by the paddle's physical Z/Y bounds.
-    if (
-      Math.abs(dz) < GameConfig.paddle.depth / 2 &&
-      Math.abs(dy) < GameConfig.paddle.height / 2
-    ) {
-      const denom = this.ball.x - prevX;
-      if (Math.abs(denom) > 0.0001) {
+    // Relative Continuous Collision Detection (CCD)
+    const denom = currentRelX - prevRelX;
+    if (Math.abs(denom) > 0.0001) {
+      const crossingT = (relPlaneX - prevRelX) / denom;
+      if (crossingT >= 0 && crossingT <= 1.0) {
+        const cBallZ = prevZ + (this.ball.z - prevZ) * crossingT;
+        const cPaddleZ = prevPaddleZ + (paddle.z - prevPaddleZ) * crossingT;
+        const cBallY = prevY + (this.ball.y - prevY) * crossingT;
+
         if (
-          (player === 1 &&
-            this.ball.vx < 0 &&
-            prevX >= planeX &&
-            this.ball.x <= planeX) ||
-          (player === 2 &&
-            this.ball.vx > 0 &&
-            prevX <= planeX &&
-            this.ball.x >= planeX)
+          Math.abs(cBallZ - cPaddleZ) < hitD &&
+          Math.abs(cBallY - this.PADDLE_Y) < hitH
         ) {
-          hitFrontFace = true;
+          if (
+            (player === 1 &&
+              relVX < 0 &&
+              prevRelX >= relPlaneX &&
+              currentRelX <= relPlaneX) ||
+            (player === 2 &&
+              relVX > 0 &&
+              prevRelX <= relPlaneX &&
+              currentRelX >= relPlaneX)
+          ) {
+            hitFrontFace = true;
+            crossBallZ = cBallZ;
+            crossPaddleZ_saved = cPaddleZ;
+          }
         }
       }
     }
 
-    // Minkowski Sum Penetration Resolver for non-CCD impacts (top, bottom, sides).
-    // Calculates overlapping volumes and resolves velocity along the axis of least penetration.
+    // Minkowski Sum Penetration Resolver using Elastic Relative Reflection
     if (
       Math.abs(dx) < hitW &&
       Math.abs(dy) < hitH &&
@@ -244,31 +352,42 @@ export class PongEngine {
       const penY = hitH - Math.abs(dy);
       const penZ = hitD - Math.abs(dz);
 
+      const relVZ = this.ball.vz - paddle.vz;
+
       if (penX <= penY && penX <= penZ) {
         if ((player === 1 && dx > 0) || (player === 2 && dx < 0))
           hitFrontFace = true;
-        else {
-          this.ball.vx *= -1;
+        else if ((dx > 0 && relVX < 0) || (dx < 0 && relVX > 0)) {
+          this.ball.vx = paddle.vx - relVX;
           this.ball.x = dx > 0 ? paddle.x + hitW : paddle.x - hitW;
         }
       } else if (penZ < penX && penZ <= penY) {
-        if ((dz > 0 && this.ball.vz < 0) || (dz < 0 && this.ball.vz > 0)) {
-          this.ball.vz *= -1;
+        if ((dz > 0 && relVZ < 0) || (dz < 0 && relVZ > 0)) {
+          this.ball.vz = paddle.vz - relVZ;
           this.ball.z = dz > 0 ? paddle.z + hitD : paddle.z - hitD;
         }
       } else {
         if ((dy > 0 && this.ball.vy < 0) || (dy < 0 && this.ball.vy > 0)) {
           this.ball.vy *= -GameConfig.ball.bounceFriction;
-          this.ball.y = dy > 0 ? PADDLE_Y + hitH : PADDLE_Y - hitH;
+          this.ball.y = dy > 0 ? this.PADDLE_Y + hitH : this.PADDLE_Y - hitH;
         }
       }
     }
 
-    // Apply specific logic for front-face hits (transferring momentum, applying spin, etc.)
     if (hitFrontFace) {
-      const newVX =
+      let newVX =
         (player === 1 ? Math.abs(this.ball.vx) : -Math.abs(this.ball.vx)) +
         paddle.vx * GameConfig.physics.paddleVelocityTransfer;
+
+      // Escape Velocity Guarantee
+      if (player === 1) {
+        newVX = Math.max(newVX, GameConfig.ball.startVelocityX);
+        newVX = Math.max(newVX, paddle.vx + 5);
+      } else {
+        newVX = Math.min(newVX, -GameConfig.ball.startVelocityX);
+        newVX = Math.min(newVX, paddle.vx - 5);
+      }
+
       this.ball.vx = Math.max(
         Math.min(newVX, GameConfig.ball.maxXVelocity),
         -GameConfig.ball.maxXVelocity,
@@ -278,8 +397,14 @@ export class PongEngine {
           ? paddle.x + hitW + GameConfig.physics.collisionNudge
           : paddle.x - hitW - GameConfig.physics.collisionNudge;
 
-      const hitPoint = dz / (GameConfig.paddle.depth / 2);
+      const hitPoint =
+        (crossBallZ - crossPaddleZ_saved) / (GameConfig.paddle.depth / 2);
       this.ball.vz += hitPoint * GameConfig.ball.deflectionBoost;
+
+      this.ball.vz = Math.max(
+        Math.min(this.ball.vz, GameConfig.ball.maxZVelocity),
+        -GameConfig.ball.maxZVelocity,
+      );
 
       if (this.mode === "advanced") {
         const newSpin =
@@ -298,20 +423,22 @@ export class PongEngine {
     this.serveTimer = launch ? 0 : GameConfig.rules.serveDelay;
     this.nextServeDirection = targetPlayer;
 
-    // Center the ball while waiting for the launch delay to expire.
     this.ball.x = 0;
+    this.ball.z = 0;
+
+    const ceilingLimit = this.CEILING - GameConfig.ball.radius;
     this.ball.y =
       this.mode === "classic"
         ? GameConfig.ball.radius
-        : GameConfig.ball.serveHeight;
-    this.ball.z = 0;
+        : Math.min(GameConfig.ball.serveHeight, ceilingLimit);
 
     if (launch) {
       this.ball.vx =
         (this.nextServeDirection === 1 ? -1 : 1) *
         GameConfig.ball.startVelocityX;
-      this.ball.vz =
-        (Math.random() > 0.5 ? 1 : -1) * GameConfig.ball.startVelocityZ;
+      const zMagnitude =
+        GameConfig.ball.startVelocityZ * (0.8 + Math.random() * 0.4);
+      this.ball.vz = (Math.random() > 0.5 ? 1 : -1) * zMagnitude;
       this.ball.vy = 0;
       this.ball.spin = 0;
     } else {

--- a/src/game/ui/GameSettingPanel.tsx
+++ b/src/game/ui/GameSettingPanel.tsx
@@ -36,6 +36,7 @@ function scaleToBallSpeed(s: number) {
   GameConfig.ball.startVelocityX = Math.round(BASE_BALL_VX * f);
   GameConfig.ball.startVelocityZ = Math.round(BASE_BALL_VZ * f);
   GameConfig.ball.maxXVelocity = Math.round(BASE_BALL_MAX * f);
+  GameConfig.ball.maxZVelocity = Math.round(14 * f);
 }
 
 function gravityToScale(g: number) {


### PR DESCRIPTION
…king, and remove redundant UI state

Physics Engine:
- Fix 'Serve Snap' by dynamically capping spawn height below non-visual ceiling.
- Implement x3 'Stratosphere Ceiling' to allow high lobs while preventing camera escape.
- Unify friction by switching ball spin decay to exponential formula.
- Fix 'Ghost Paddle' bug by applying vz tracking and Phantom Momentum clamps to Classic Mode.
- Move constants to constructor to prevent stale settings on live UI updates.

AI Opponent:
- Implement double-ricochet prediction math for intercepting high lobs off the ceiling.
- Add strict velocity epsilon checks for stable serve-state detection.

Settings & UI:
- Fix asymmetric velocity cap by scaling maxZVelocity dynamically in GamePrefs and UI panel.
- Remove bloated 'flipped' React state and CameraFlipWatcher, deferring to native 3D back-face rendering.