### PR TITLE
add tips when game setting panel is open & undisplay disabled buttons

### DIFF
--- a/src/game/ui/GameSetup.tsx
+++ b/src/game/ui/GameSetup.tsx
@@ -30,7 +30,8 @@ export default function GameSetup({
   );
   const [selectedOpponent, setSelectedOpponent] = useState<GameOpponent>(
     initialPrefs?.opponent === "human"
-      ? "human" : (initialPrefs?.opponent ?? "medium"),
+      ? "human"
+      : (initialPrefs?.opponent ?? "medium"),
   );
   const [guestName, setGuestName] = useState("");
   const [aiDifficulty, setAiDifficulty] = useState<"easy" | "medium" | "hard">(

--- a/src/game/ui/GameUI.tsx
+++ b/src/game/ui/GameUI.tsx
@@ -59,9 +59,15 @@ export default function GameUI({
             <span className="text-2xl sm:text-3xl font-bold tracking-wide text-text">
               {t("game.play.ready")}
             </span>
-            <span className="text-xs sm:text-sm text-text/50 tracking-widest uppercase">
-              {t("game.play.clickOrSpace")}
-            </span>
+            {menuOpen ? (
+              <span className="text-xs sm:text-sm text-text/50 tracking-widest uppercase">
+                {t("game.play.settingOpen")}
+              </span>
+            ) : (
+              <span className="text-xs sm:text-sm text-text/50 tracking-widest uppercase">
+                {t("game.play.clickOrSpace")}
+              </span>
+            )}
           </div>
         </div>
       )}
@@ -79,20 +85,26 @@ export default function GameUI({
             <span className="text-2xl sm:text-3xl font-bold tracking-wide text-text">
               {t("game.play.paused")}
             </span>
-            <div className="flex gap-2 sm:gap-3">
-              <Button
-                className="w-32 sm:w-40 py-2.5 sm:py-3 bg-btn-purple hover:bg-btn-purple-hover font-semibold justify-center"
-                onClick={() => dispatch(resumeAction())}
-              >
-                {t("game.play.continue")}
-              </Button>
-              <Button
-                className="w-32 sm:w-40 py-2.5 sm:py-3 bg-btn-purple hover:bg-btn-purple-hover font-semibold justify-center"
-                onClick={() => dispatch(exitPromptAction())}
-              >
-                {t("game.play.endGame")}
-              </Button>
-            </div>
+            {menuOpen ? (
+              <span className="text-xs sm:text-sm text-text/50 tracking-widest uppercase">
+                {t("game.play.settingOpen")}
+              </span>
+            ) : (
+              <div className="flex gap-2 sm:gap-3">
+                <Button
+                  className="w-32 sm:w-40 py-2.5 sm:py-3 bg-btn-purple hover:bg-btn-purple-hover font-semibold justify-center"
+                  onClick={() => dispatch(resumeAction())}
+                >
+                  {t("game.play.continue")}
+                </Button>
+                <Button
+                  className="w-32 sm:w-40 py-2.5 sm:py-3 bg-btn-purple hover:bg-btn-purple-hover font-semibold justify-center"
+                  onClick={() => dispatch(exitPromptAction())}
+                >
+                  {t("game.play.endGame")}
+                </Button>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -377,6 +377,7 @@
     "play": {
       "ready": "Ready?",
       "clickOrSpace": "Click or press Space",
+      "settingOpen": "Finish settings before continuing",
       "paused": "Paused",
       "continue": "Continue",
       "endGame": "End Game"

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -370,6 +370,7 @@
     "play": {
       "ready": "Valmis?",
       "clickOrSpace": "Klikkaa tai paina välilyöntiä",
+      "settingOpen": "Viimeistele asetukset ennen jatkamista",
       "gameTips": "Käytä WASD-näppäimiä mailan ohjaamiseen",
       "paused": "Tauko",
       "continue": "Jatka",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -370,6 +370,7 @@
     "play": {
       "ready": "准备好了吗？",
       "clickOrSpace": "点击或按空格键开始游戏",
+      "settingOpen": "请先完成游戏设置",
       "gameTips": "使用WASD控制球拍",
       "paused": "已暂停",
       "continue": "继续",


### PR DESCRIPTION
- add tips for when the game setting panel is open, to reminder user close the setting first.
- undisplay the continue and end game btns then the game setting panel is open.
- fix a small eslint issue in GameSetup.tsx(sorry forgot to check it in last pr)