### PR TITLE
[fix:] displayName strict requirement for navigation, character limit…

### DIFF
--- a/src/actions/registration.ts
+++ b/src/actions/registration.ts
@@ -48,6 +48,10 @@ export async function registerUserAction(email: string, password: string) {
     return { ok: false, error: apiErrors.passwordTooShort };
   }
 
+  if (email.length > 100) {
+    return { ok: false, error: apiErrors.emailTooLong };
+  }
+
   const userExists = await prisma.user.findFirst({
     where: {
       OR: [{ email }],

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -7,6 +7,7 @@ import {
   getSentFriendRequestsByUserId,
 } from "@/data/friendships";
 import { FriendsClient } from "@/components/friends/FriendsClient";
+import { getCurrentUser } from "@/data/user";
 
 // ---------- Helpers ----------
 function resolveLabel(u: { displayName: string | null }): string {
@@ -21,6 +22,9 @@ function avatarUrl(userId: string): string {
 export default async function FriendsPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) redirect("/login");
+
+  const user = await getCurrentUser();
+  if (!user?.displayName) redirect("/registration/profile");
 
   const userId = session.user.id;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,48 +1,10 @@
-// Home page
-"use client";
+import { getCurrentUser } from "@/data/user";
+import { redirect } from "next/navigation";
+import HomeClient from "@/components/home/HomeClient";
 
-import { useTranslation } from "react-i18next";
-import Link from "next/link";
-import Image from "next/image";
+export default async function HomePage() {
+  const user = await getCurrentUser();
+  if (user && !user.displayName) redirect("/registration/profile");
 
-export default function Home() {
-  const { t } = useTranslation();
-
-  return (
-    <div className="relative flex-1 rounded-xl overflow-hidden flex items-center">
-      {/* left part */}
-      <div className="space-y-6 w-full max-w-7xl mx-auto px-0 md:px-16 lg:px-24">
-        <h1 className="font-bold text-text text-4xl md:text-5xl lg:text-6xl">
-          {t("home.welcome")}
-        </h1>
-
-        <p className="text-text text-xl md:text-2xl">{t("home.intro")}</p>
-
-        <div className="inline-flex">
-          <Link
-            href="/game"
-            className="
-              px-24 py-4 rounded-2xl
-              text-white text-4xl
-              bg-gradient-to-r from-blue-dark to-purple-dark
-              shadow-md
-              hover:scale-105 active:scale-95
-              transition-transform duration-200 will-change-transform
-            "
-          >
-            {t("home.startgame")}
-          </Link>
-        </div>
-      </div>
-
-      {/* right part */}
-      <Image
-        src="/images/placeholder_homepage.png"
-        alt="preview"
-        width={1024}
-        height={1024}
-        className="h-full w-auto ml-auto object-cover"
-      />
-    </div>
-  );
+  return <HomeClient />;
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -88,5 +88,6 @@ export default async function ProfilePage() {
   if (!session?.user?.email) redirect("/login");
   const data = await getProfileData(session.user.email);
   if (!data) redirect("/login");
+  if (!data.user.displayName) redirect("/registration/profile");
   return <ProfileClient data={data} />;
 }

--- a/src/app/registration/profile/page.tsx
+++ b/src/app/registration/profile/page.tsx
@@ -11,6 +11,8 @@ import {
 
 type AvatarChoice = "default" | "github" | "upload";
 
+const NAME_MAX = 20;
+
 export default function ProfileSetupPage() {
   const [displayName, setDisplayName] = useState("");
   const [avatarChoice, setAvatarChoice] = useState<AvatarChoice>("default");
@@ -28,6 +30,8 @@ export default function ProfileSetupPage() {
 
   const showGithubOption = !!session?.user?.image;
 
+  const nameTooLong = displayName.length > NAME_MAX;
+
   const handleAvatarChoice = (choice: AvatarChoice) => {
     setAvatarChoice(choice);
     setError("");
@@ -39,7 +43,7 @@ export default function ProfileSetupPage() {
   };
 
   useEffect(() => {
-    if (!displayName.trim()) {
+    if (!displayName.trim() || nameTooLong) {
       setUsernameAvailable(null);
       return;
     }
@@ -52,10 +56,16 @@ export default function ProfileSetupPage() {
       setCheckingUsername(false);
     }, 500);
     return () => clearTimeout(timeout);
-  }, [displayName]);
+  }, [displayName, nameTooLong]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (nameTooLong) {
+      setError(t("settings.account.nameTooLong", { max: NAME_MAX }));
+      return;
+    }
+
     if (!usernameAvailable) return;
     setError("");
     setLoading(true);
@@ -123,18 +133,36 @@ export default function ProfileSetupPage() {
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col gap-1">
-            <label className="text-sm font-medium text-text/70">
-              {t("profile.userNameLabel")}
-            </label>
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium text-text/70">
+                {t("profile.userNameLabel")}
+              </label>
+              <span
+                className={`text-xs tabular-nums ${
+                  nameTooLong ? "text-red-500" : "text-text/40"
+                }`}
+              >
+                {displayName.length} / {NAME_MAX}
+              </span>
+            </div>
             <input
               type="text"
               placeholder={t("profile.userNamePlaceholder")}
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
-              className="w-full px-4 py-2.5 rounded-lg text-sm text-text bg-button border border-purple-light placeholder:text-text/40 focus:outline-none focus:ring-2 focus:ring-purple-light transition-all"
+              className={`w-full px-4 py-2.5 rounded-lg text-sm text-text bg-button border placeholder:text-text/40 focus:outline-none focus:ring-2 transition-all ${
+                nameTooLong
+                  ? "border-red-500/60 focus:ring-red-500/30"
+                  : "border-purple-light focus:ring-purple-light"
+              }`}
               required
             />
-            {displayName.trim() && (
+            {nameTooLong && (
+              <p className="text-xs text-red-500">
+                {t("settings.account.nameTooLong", { max: NAME_MAX })}
+              </p>
+            )}
+            {!nameTooLong && displayName.trim() && (
               <p
                 className={`text-xs mt-0.5 ${
                   checkingUsername
@@ -236,7 +264,9 @@ export default function ProfileSetupPage() {
 
           <Button
             type="submit"
-            disabled={loading || !usernameAvailable || checkingUsername}
+            disabled={
+              loading || nameTooLong || !usernameAvailable || checkingUsername
+            }
             className="bg-gradient-to-r from-blue-dark to-purple-dark mt-1 text-white text-xl"
           >
             {loading ? t("profile.loading") : t("profile.submit")}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -14,6 +14,10 @@ export default async function SettingsPage({
     redirect("/login");
   }
 
+  if (!user.displayName) {
+    redirect("/registration/profile");
+  }
+
   return (
     <SettingsClient
       user={{

--- a/src/components/EditProfileForm.tsx
+++ b/src/components/EditProfileForm.tsx
@@ -15,6 +15,7 @@ interface EditProfileFormProps {
 }
 
 const BIO_MAX = 150;
+const NAME_MAX = 20;
 
 function useUsernameCheck(nameValue: string, originalName: string | null) {
   const [usernameAvailable, setUsernameAvailable] = useState<boolean>(true);
@@ -73,6 +74,7 @@ export function EditProfileForm({
   );
 
   const bioTooLong = bioValue.length > BIO_MAX;
+  const nameTooLong = nameValue.length > NAME_MAX;
   const nameChanged = nameValue.trim() !== (displayName ?? "").trim();
 
   const clearSelectedFile = () => {
@@ -84,6 +86,11 @@ export function EditProfileForm({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (nameTooLong) {
+      setError(t("settings.account.nameTooLong", { max: NAME_MAX }));
+      return;
+    }
 
     if (bioTooLong) {
       setError(t("settings.account.bioTooLong", { max: BIO_MAX }));
@@ -127,16 +134,34 @@ export function EditProfileForm({
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       <div className="flex flex-col gap-1">
-        <label className="text-sm font-medium text-text/70">
-          {t("settings.account.userName")}
-        </label>
+        <div className="flex items-center justify-between">
+          <label className="text-sm font-medium text-text/70">
+            {t("settings.account.userName")}
+          </label>
+          <span
+            className={`text-xs tabular-nums ${
+              nameTooLong ? "text-red-500" : "text-text/40"
+            }`}
+          >
+            {nameValue.length} / {NAME_MAX}
+          </span>
+        </div>
         <input
           type="text"
           value={nameValue}
           onChange={(e) => setNameValue(e.target.value)}
-          className="w-full px-4 py-2.5 rounded-lg text-sm text-text bg-button border border-purple-light placeholder:text-text/40 focus:outline-none focus:ring-2 focus:ring-purple-light transition-all"
+          className={`w-full px-4 py-2.5 rounded-lg text-sm text-text bg-button border placeholder:text-text/40 focus:outline-none focus:ring-2 transition-all ${
+            nameTooLong
+              ? "border-red-500/60 focus:ring-red-500/30"
+              : "border-purple-light focus:ring-purple-light"
+          }`}
         />
-        {nameChanged && nameValue.trim() && (
+        {nameTooLong && (
+          <p className="text-xs text-red-500">
+            {t("settings.account.nameTooLong", { max: NAME_MAX })}
+          </p>
+        )}
+        {!nameTooLong && nameChanged && nameValue.trim() && (
           <p
             className={`text-xs mt-0.5 ${
               checkingUsername
@@ -250,6 +275,7 @@ export function EditProfileForm({
         type="submit"
         disabled={
           loading ||
+          nameTooLong ||
           bioTooLong ||
           checkingUsername ||
           (nameChanged && !usernameAvailable)

--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import Link from "next/link";
+import Image from "next/image";
+
+export default function HomeClient() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="relative flex-1 rounded-xl overflow-hidden flex items-center">
+      {/* left part */}
+      <div className="space-y-6 w-full max-w-7xl mx-auto px-0 md:px-16 lg:px-24">
+        <h1 className="font-bold text-text text-4xl md:text-5xl lg:text-6xl">
+          {t("home.welcome")}
+        </h1>
+
+        <p className="text-text text-xl md:text-2xl">{t("home.intro")}</p>
+
+        <div className="inline-flex">
+          <Link
+            href="/game"
+            className="
+              px-24 py-4 rounded-2xl
+              text-white text-4xl
+              bg-gradient-to-r from-blue-dark to-purple-dark
+              shadow-md
+              hover:scale-105 active:scale-95
+              transition-transform duration-200 will-change-transform
+            "
+          >
+            {t("home.startgame")}
+          </Link>
+        </div>
+      </div>
+
+      {/* right part */}
+      <Image
+        src="/images/placeholder_homepage.png"
+        alt="preview"
+        width={1024}
+        height={1024}
+        className="h-full w-auto ml-auto object-cover"
+      />
+    </div>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -184,7 +184,8 @@
       "saving": "Saving...",
       "saveChanges": "Save changes",
       "chooseFile": "Choose file",
-      "noFileChosen": "No file chosen"
+      "noFileChosen": "No file chosen",
+      "nameTooLong": "Username must be {{max}} characters or fewer"
     },
     "security": {
       "title": "Security",
@@ -226,7 +227,8 @@
     "internalServerError": "An internal server error occurred.",
     "invalidImageUrl": "The image URL is invalid or unreachable.",
     "fileTooLarge": "Image is too large. Please choose a file under 2MB.",
-    "errorUnexpected": "An unexpected error occurred. Please try again."
+    "errorUnexpected": "An unexpected error occurred. Please try again.",
+    "emailTooLong": "Entered Email is too long, max 100 characters allowed"
   },
   "friendshipErrors": {
     "cannotAddSelf": "You cannot send a friend request to yourself",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -178,7 +178,8 @@
       "saving": "Tallennetaan...",
       "saveChanges": "Tallenna muutokset",
       "chooseFile": "Valitse tiedosto",
-      "noFileChosen": "Ei tiedostoa valittu"
+      "noFileChosen": "Ei tiedostoa valittu",
+      "nameTooLong": "Käyttäjänimi saa olla enintään {{max}} merkkiä"
     },
     "security": {
       "title": "Turvallisuus",
@@ -220,7 +221,8 @@
     "internalServerError": "Palvelimella tapahtui sisäinen virhe.",
     "invalidImageUrl": "Kuvan URL-osoite on virheellinen tai se ei ole saavutettavissa.",
     "fileTooLarge": "Kuva on liian suuri. Valitse alle 2 Mt:n tiedosto.",
-    "errorUnexpected": "Odottamaton virhe. Yritä uudelleen."
+    "errorUnexpected": "Odottamaton virhe. Yritä uudelleen.",
+    "emailTooLong": "Syötetty sähköpostiosoite on liian pitkä, enintään 100 merkkiä sallittu"
   },
   "friendshipErrors": {
     "cannotAddSelf": "Et voi lähettää kaveripyyntöä itsellesi",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -178,7 +178,8 @@
       "saving": "保存中...",
       "saveChanges": "保存更改",
       "chooseFile": "选择文件",
-      "noFileChosen": "未选择文件"
+      "noFileChosen": "未选择文件",
+      "nameTooLong": "用户名不能超过 {{max}} 个字符"
     },
     "security": {
       "title": "安全",
@@ -220,7 +221,8 @@
     "internalServerError": "服务器内部错误。",
     "invalidImageUrl": "图片链接无效或无法访问。",
     "fileTooLarge": "图片太大，请选择小于 2MB 的文件。",
-    "errorUnexpected": "发生意外错误，请重试。"
+    "errorUnexpected": "发生意外错误，请重试。",
+    "emailTooLong": "输入的邮箱地址过长，最多允许 100 个字符"
   },
   "friendshipErrors": {
     "cannotAddSelf": "不能向自己发送好友请求",

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -12,6 +12,7 @@ export const apiErrors = {
   invalidImageUrl: "invalidImageUrl",
   fileTooLarge: "fileTooLarge",
   errorUnexpected: "errorUnexpected",
+  emailTooLong: "emailTooLong",
 } as const;
 
 export type ApiErrorKey = keyof typeof apiErrors;


### PR DESCRIPTION
A few things were implemented around displayName/registration: 
1) It used to be that you were prompted to enter Username but then you would still be able to discard this step and navigate to other pages (friends, home etc). It didnt create any errors or warnings, and you just weren't able to be found by friends but then when you did set a username it would not be that one that shows on the page. So anyway this was fixed, and now you will be redirected to the profile setup. 
RULE EXCLUSION: 
The pages that you can navigate to are: terms, privacy and game page. This last one, you will be able to play a game without setting your display name, and the match will be saved without issues, then when you try to go somehwere (home, user profile ) you will be prompted again to insert display name, which once you do, will show everything as normal and matches will be there. 

2) Username/dispalyname character limit set to 20, both in the regsitration/profile page and both in the EditProfileForm in settings page 

3) Introduced an email character limit, set to 100. This was done in the prisma actions function: registerUserAction(). The error is caught and displayed accordingly 

4) Appropriate error translations included 