### PR TITLE
[fix:] add tips for player2 name maxlength when playing with guest

### DIFF
--- a/src/game/ui/GameSetup.tsx
+++ b/src/game/ui/GameSetup.tsx
@@ -47,7 +47,9 @@ export default function GameSetup({
     !isLoggedIn &&
     (selectedType === "advanced" || selectedOpponent === "human");
 
-  const canStart = !requiresLogin && (isAI || guestName.trim().length > 0);
+  const canStart =
+    !requiresLogin &&
+    (isAI || (guestName.trim().length > 0 && guestName.length <= 20));
 
   const handleWinScore = useCallback((v: WinScore) => setWinScore(v), []);
 
@@ -157,12 +159,21 @@ export default function GameSetup({
                 value={guestName}
                 onChange={(e) => setGuestName(e.target.value)}
                 placeholder={t("game.setup.player2Placeholder")}
-                maxLength={20}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && canStart) handleStart();
                 }}
-                className="w-full px-3 sm:px-4 py-2.5 sm:py-3 md:py-4 rounded-lg sm:rounded-xl text-sm sm:text-base md:text-lg text-center text-text bg-card border border-text/10 outline-none placeholder:text-text/25 focus:border-purple-dark"
+                className={[
+                  "w-full px-3 sm:px-4 py-2.5 sm:py-3 md:py-4 rounded-lg sm:rounded-xl text-sm sm:text-base md:text-lg text-center text-text bg-card border outline-none placeholder:text-text/25",
+                  guestName.length > 20
+                    ? "border-red-500 focus:border-red-500"
+                    : "border-text/10 focus:border-purple-dark",
+                ].join(" ")}
               />
+              {guestName.length > 20 && (
+                <p className="text-xs text-red-500 text-center">
+                  {t("game.setup.player2MaxLength")}
+                </p>
+              )}
             </section>
           )}
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -350,6 +350,7 @@
       "hard": "Hard",
       "player2Name": "Player 2 Name",
       "player2Placeholder": "Enter a name to continue...",
+      "player2MaxLength": "Name must be 20 characters or fewer",
       "winScore": "Win Score",
       "startPlay": "Start Play",
       "loginToUnlock": "Log in to unlock more game modes"

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -344,6 +344,7 @@
       "hard": "Vaikea",
       "player2Name": "Pelaaja 2:n nimi",
       "player2Placeholder": "Kirjoita nimi jatkaaksesi...",
+      "player2MaxLength": "Nimi voi olla enintään 20 merkkiä",
       "winScore": "Voittopisteet",
       "startPlay": "Aloita peli",
       "loginToUnlock": "Kirjaudu sisään avataksesi lisää pelitiloja"

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -344,6 +344,7 @@
       "hard": "困难",
       "player2Name": "玩家 2 名称",
       "player2Placeholder": "输入名称以继续...",
+      "player2MaxLength": "名字最多20个字符",
       "winScore": "胜利分数",
       "startPlay": "开始游戏",
       "loginToUnlock": "登录以解锁更多游戏模式"


### PR DESCRIPTION
Player 2's name originally had a 20-character input limit, but without any prompts, which could confuse users. Furthermore, Chinese characters could exceed 20 characters. 

Now, the 20-character limit has been removed; when the name exceeds 20 characters, a prompt is added and the "Start Game" button is disabled.