### PR TITLE
Ensure avatarVersion is always available and user for forming avatarUrl

### DIFF
--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -4,7 +4,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
-type UserResult = { id: string; label: string };
+type UserResult = { id: string; label: string; avatarVersion: number };
 
 export async function searchUsersForFriendRequest(
   keyword: string,
@@ -38,7 +38,7 @@ export async function searchUsersForFriendRequest(
         { displayName: { startsWith: trimmed } },
       ],
     },
-    select: { id: true, displayName: true, bio: true },
+    select: { id: true, displayName: true, bio: true, updatedAt: true },
     take: 20,
   });
 
@@ -46,5 +46,6 @@ export async function searchUsersForFriendRequest(
     id: u.id,
     label: u.displayName ?? "Unknown user",
     bio: u.bio,
+    avatarVersion: u.updatedAt.getTime(),
   }));
 }

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -14,8 +14,14 @@ function resolveLabel(u: { displayName: string | null }): string {
   return u.displayName ?? "Unknown user";
 }
 
-function avatarUrl(userId: string): string {
-  return `/api/avatar/${userId}`;
+function avatarUrl({
+  id,
+  avatarVersion,
+}: {
+  id: string;
+  avatarVersion: number;
+}): string {
+  return `/api/avatar/${id}?v=${avatarVersion}`;
 }
 
 // ---------- Page ----------
@@ -41,7 +47,7 @@ export default async function FriendsPage() {
         friendshipId: f.id,
         label: resolveLabel(f.requester),
         bio: f.requester.bio,
-        avatarUrl: avatarUrl(f.requester.id),
+        avatarUrl: avatarUrl(f.requester),
         isOnline: f.requester.isOnline,
       }))}
       sentRequests={sentRequests.map((f) => ({
@@ -49,7 +55,7 @@ export default async function FriendsPage() {
         friendshipId: f.id,
         label: resolveLabel(f.addressee),
         bio: f.addressee.bio,
-        avatarUrl: avatarUrl(f.addressee.id),
+        avatarUrl: avatarUrl(f.addressee),
         isOnline: f.addressee.isOnline,
       }))}
       friends={friends.map((f) => {
@@ -60,7 +66,7 @@ export default async function FriendsPage() {
           friendshipId: f.id,
           label: resolveLabel(friend),
           bio: friend.bio,
-          avatarUrl: avatarUrl(friend.id),
+          avatarUrl: avatarUrl(friend),
           isOnline: friend.isOnline,
         };
       })}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,13 +12,12 @@ import { useTranslation } from "react-i18next";
 
 export default function Header() {
   const pathname = usePathname();
-  const { data: session, status } = useSession();
+  const { data: session } = useSession();
   const { t } = useTranslation();
 
-  const avatarSrc =
-    status === "authenticated" && session.user?.id
-      ? `/api/avatar/${session.user.id}?v=${session.user.avatarVersion}`
-      : "/images/user_icon.png";
+  const avatarSrc = session?.user
+    ? `/api/avatar/${session.user.id}?v=${session.user.avatarVersion}`
+    : "/images/user_icon.png";
 
   return (
     <Bar>

--- a/src/components/friends/DiscoverUserCard.tsx
+++ b/src/components/friends/DiscoverUserCard.tsx
@@ -8,7 +8,7 @@ import PersonCard from "./PersonCard";
 type Props = {
   userId: string;
   label: string;
-  avatarUrl?: string | null;
+  avatarUrl: string;
   isSelected?: boolean;
   onSelect?: () => void;
   onSuccess?: () => void;

--- a/src/components/friends/FriendCard.tsx
+++ b/src/components/friends/FriendCard.tsx
@@ -5,7 +5,7 @@ import PersonCard from "./PersonCard";
 type Props = {
   friendshipId: string;
   label: string;
-  avatarUrl?: string | null;
+  avatarUrl: string;
   isOnline?: boolean;
   onSelect: () => void;
   isSelected: boolean;

--- a/src/components/friends/FriendProfile.tsx
+++ b/src/components/friends/FriendProfile.tsx
@@ -27,7 +27,7 @@ type Props = {
     friendshipId?: string;
     label: string;
     bio?: string | null;
-    avatarUrl?: string | null;
+    avatarUrl: string;
   };
   isFriend?: boolean;
   onClose: () => void;

--- a/src/components/friends/FriendsClient.tsx
+++ b/src/components/friends/FriendsClient.tsx
@@ -15,7 +15,7 @@ type Person = {
   friendshipId?: string;
   label: string;
   bio?: string | null;
-  avatarUrl?: string | null;
+  avatarUrl: string;
   isOnline?: boolean;
 };
 type ActiveTab = "friends" | "incoming" | "sent";
@@ -118,7 +118,7 @@ export function FriendsClient({
     setSearchResults(
       results.map((u) => ({
         ...u,
-        avatarUrl: `/api/avatar/${u.id}`,
+        avatarUrl: `/api/avatar/${u.id}?v=${u.avatarVersion}`,
         isOnline: false,
       })),
     );
@@ -426,7 +426,7 @@ export function FriendsClient({
                       key={u.id}
                       userId={u.id}
                       label={u.label}
-                      avatarUrl={`/api/avatar/${u.id}`}
+                      avatarUrl={u.avatarUrl}
                       isSelected={selectedId === u.id}
                       onSelect={() => selectFromSearch(u)}
                       onSuccess={() => {

--- a/src/components/friends/PersonCard.tsx
+++ b/src/components/friends/PersonCard.tsx
@@ -4,7 +4,7 @@ import UserAvatar from "./UserAvatar";
 
 type Props = {
   label: string;
-  avatarUrl?: string | null;
+  avatarUrl: string;
   sublabel?: string;
   isSelected?: boolean;
   online?: boolean;

--- a/src/components/friends/RequestCard.tsx
+++ b/src/components/friends/RequestCard.tsx
@@ -14,7 +14,7 @@ type RequestCardVariant = "incoming" | "sent";
 type Props = {
   friendshipId: string;
   label: string;
-  avatarUrl?: string | null;
+  avatarUrl: string;
   isOnline?: boolean;
   isSelected: boolean;
   variant: RequestCardVariant;

--- a/src/components/friends/UserAvatar.tsx
+++ b/src/components/friends/UserAvatar.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 
 type Props = {
   label: string;
-  avatarUrl?: string | null;
+  avatarUrl: string;
   size?: "sm" | "md" | "lg";
 };
 
@@ -19,7 +19,7 @@ export default function UserAvatar({ label, avatarUrl, size = "md" }: Props) {
 
   return (
     <Image
-      src={avatarUrl ?? "/api/avatar/default"}
+      src={avatarUrl}
       alt={label}
       width={pixelSizes[size]}
       height={pixelSizes[size]}

--- a/src/data/friendships.ts
+++ b/src/data/friendships.ts
@@ -63,6 +63,7 @@ const userDisplayFields = {
   username: true,
   bio: true,
   lastActiveAt: true,
+  updatedAt: true,
 } as const;
 
 export async function getPendingFriendRequestsByUserId(userId: string) {
@@ -86,6 +87,8 @@ export async function getPendingFriendRequestsByUserId(userId: string) {
       ...request.requester,
       isOnline: isUserOnline(request.requester.lastActiveAt),
       lastActiveAt: undefined,
+      avatarVersion: request.requester.updatedAt.getTime(),
+      updatedAt: undefined,
     },
   }));
 }
@@ -111,6 +114,8 @@ export async function getSentFriendRequestsByUserId(userId: string) {
       ...request.addressee,
       isOnline: isUserOnline(request.addressee.lastActiveAt),
       lastActiveAt: undefined,
+      avatarVersion: request.addressee.updatedAt.getTime(),
+      updatedAt: undefined,
     },
   }));
 }
@@ -138,11 +143,15 @@ export async function getAcceptedFriendsByUserId(userId: string) {
       ...friendship.requester,
       isOnline: isUserOnline(friendship.requester.lastActiveAt),
       lastActiveAt: undefined,
+      avatarVersion: friendship.requester.updatedAt.getTime(),
+      updatedAt: undefined,
     },
     addressee: {
       ...friendship.addressee,
       isOnline: isUserOnline(friendship.addressee.lastActiveAt),
       lastActiveAt: undefined,
+      avatarVersion: friendship.addressee.updatedAt.getTime(),
+      updatedAt: undefined,
     },
   }));
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -65,7 +65,7 @@ export const authOptions: NextAuthOptions = {
 
       if (session.user) {
         session.user.id = token.userId;
-        session.user.avatarVersion = user?.updatedAt.getTime();
+        session.user.avatarVersion = user.updatedAt.getTime();
       }
       return session;
     },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -4,7 +4,7 @@ declare module "next-auth" {
   interface Session {
     user?: {
       id: string;
-      avatarVersion?: number;
+      avatarVersion: number;
     } & DefaultSession["user"];
   }
 }


### PR DESCRIPTION
* Session data, Header: avatarVersion is not optional.
* UserAvatar and other friends page components: avatarUrl is not optional. Remove unnecessary fallback to `/api/avatar/default` (was not implemented).
* FriendsClient: generate avatarUrl with avatarVersion.
* Friends data getters and actions: include avatarVersion in the return type.

Fixes #71.