### PR TITLE
Clean up account deletion flow

### DIFF
--- a/src/actions/account.ts
+++ b/src/actions/account.ts
@@ -94,12 +94,6 @@ export async function deleteProfileAction() {
     await prisma.user.delete({
       where: { email: session.user.email },
     });
-
-    revalidatePath("/");
-    revalidatePath("/settings");
-    revalidatePath("/profile");
-    revalidatePath("/friends");
-
     return { ok: true };
   } catch (error) {
     console.error("deleteProfileAction error:", error);

--- a/src/components/DeleteProfileButton.tsx
+++ b/src/components/DeleteProfileButton.tsx
@@ -31,9 +31,7 @@ export function DeleteProfileButton() {
       return;
     }
 
-    await signOut({ redirect: false });
-    router.push("/");
-    router.refresh();
+    await signOut({ callbackUrl: "/" });
   };
 
   return (


### PR DESCRIPTION
Remove the unnecessary revalidation from the deletion action. It was causing /settings to notice invalid session and redirect to login while at the same time the client side code tried to go to front page.

In client side code, go to front page with a reload to ensure no stale state remains in memory.