### PR TITLE
Avoid raw window.location.href navigation

### DIFF
--- a/src/app/registration/_pageClient.tsx
+++ b/src/app/registration/_pageClient.tsx
@@ -6,12 +6,14 @@ import Button from "@/components/Button";
 import { signIn } from "next-auth/react";
 import { useTranslation } from "react-i18next";
 import { registerUserAction } from "@/actions/registration";
+import { useRouter } from "next/navigation";
 
 export default function RegistrationPageClient() {
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
+  const router = useRouter();
   const { t } = useTranslation();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -38,11 +40,11 @@ export default function RegistrationPageClient() {
       }
 
       if (result.needsProfile === false) {
-        window.location.href = "/";
+        router.push("/");
         return;
       }
 
-      window.location.href = "/registration/profile";
+      router.push("/registration/profile");
       return;
     } catch (err: unknown) {
       if (err instanceof Error) {

--- a/src/app/registration/profile/page.tsx
+++ b/src/app/registration/profile/page.tsx
@@ -8,6 +8,7 @@ import {
   completeRegistrationProfileAction,
   checkUsernameAvailableAction,
 } from "@/actions/registration";
+import { useRouter } from "next/navigation";
 
 type AvatarChoice = "default" | "github" | "upload";
 
@@ -23,6 +24,7 @@ export default function ProfileSetupPage() {
     null,
   );
   const [checkingUsername, setCheckingUsername] = useState(false);
+  const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const { t } = useTranslation();
@@ -102,7 +104,7 @@ export default function ProfileSetupPage() {
       }
 
       updateSession();
-      window.location.href = "/";
+      router.push("/");
     } catch (err: unknown) {
       if (err instanceof Error && err.message.includes("Unique constraint")) {
         setError(t("profile.usernameTaken"));


### PR DESCRIPTION
It throws away partly usable page state for no reason, and causes errors on the unloading page as server requests are interrupted.